### PR TITLE
admin / 관리자 게시글 상세 조회 API 및 댓글 페이징 API 추가

### DIFF
--- a/admin-server/src/main/java/com/beta/controller/post/PostController.java
+++ b/admin-server/src/main/java/com/beta/controller/post/PostController.java
@@ -1,10 +1,15 @@
 package com.beta.controller.post;
 
 import com.beta.application.post.AdminPostQueryFacadeService;
+import com.beta.community.application.admin.AdminPostDetailFacadeService;
+import com.beta.community.application.admin.dto.AdminPostCommentsResult;
+import com.beta.community.application.admin.dto.AdminPostDetailResult;
 import com.beta.community.application.admin.dto.AdminPostQueryResult;
 import com.beta.controller.common.request.AdminPageRequest;
 import com.beta.controller.common.response.AdminPageResponse;
 import com.beta.controller.post.request.AdminPostSearchRequest;
+import com.beta.controller.post.response.AdminPostCommentsResponse;
+import com.beta.controller.post.response.AdminPostDetailResponse;
 import com.beta.controller.post.response.AdminPostItemResponse;
 import com.beta.core.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +25,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final AdminPostQueryFacadeService adminPostQueryFacadeService;
+    private final AdminPostDetailFacadeService adminPostDetailFacadeService;
 
     @Operation(summary = "관리자 게시글 목록 조회")
     @ApiResponses({
@@ -65,5 +73,52 @@ public class PostController {
 
         Page<AdminPostItemResponse> responsePage = result.map(AdminPostItemResponse::from);
         return ResponseEntity.ok(AdminPageResponse.from(responsePage));
+    }
+
+    @Operation(summary = "관리자 게시글 상세 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AdminPostDetailResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "게시글 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"code": "COMMUNITY004", "message": "게시글을 찾을 수 없습니다", "timestamp": "2025-01-01T00:00:00"}""")))
+    })
+    @GetMapping("/{postId}")
+    public ResponseEntity<AdminPostDetailResponse> getPostDetail(@PathVariable Long postId) {
+        AdminPostDetailResult result = adminPostDetailFacadeService.getPostDetail(postId);
+        return ResponseEntity.ok(AdminPostDetailResponse.from(result));
+    }
+
+    @Operation(summary = "관리자 게시글 댓글 추가 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AdminPostCommentsResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "게시글 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{postId}/comments")
+    public ResponseEntity<AdminPostCommentsResponse> getComments(
+            @PathVariable Long postId,
+            @RequestParam(required = false) Long cursor
+    ) {
+        AdminPostCommentsResult result = adminPostDetailFacadeService.getComments(postId, cursor);
+        return ResponseEntity.ok(AdminPostCommentsResponse.from(result));
     }
 }

--- a/admin-server/src/main/java/com/beta/controller/post/response/AdminPostCommentsResponse.java
+++ b/admin-server/src/main/java/com/beta/controller/post/response/AdminPostCommentsResponse.java
@@ -1,0 +1,48 @@
+package com.beta.controller.post.response;
+
+import com.beta.community.application.admin.dto.AdminPostCommentsResult;
+import com.beta.community.application.admin.dto.AdminPostDetailResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "관리자 게시글 댓글 목록 응답")
+public record AdminPostCommentsResponse(
+        List<AdminPostDetailResponse.CommentResponse> comments,
+        boolean hasNext,
+        Long nextCursor
+) {
+    public static AdminPostCommentsResponse from(AdminPostCommentsResult dto) {
+        return new AdminPostCommentsResponse(
+                toCommentResponses(dto.comments()),
+                dto.hasNext(),
+                dto.nextCursor()
+        );
+    }
+
+    static List<AdminPostDetailResponse.CommentResponse> toCommentResponses(List<AdminPostDetailResult.CommentResult> comments) {
+        if (comments == null) {
+            return List.of();
+        }
+
+        return comments.stream()
+                .map(AdminPostCommentsResponse::toCommentResponse)
+                .toList();
+    }
+
+    static AdminPostDetailResponse.CommentResponse toCommentResponse(AdminPostDetailResult.CommentResult dto) {
+        return new AdminPostDetailResponse.CommentResponse(
+                dto.commentId(),
+                dto.userId(),
+                dto.nickname(),
+                dto.teamCode(),
+                dto.content(),
+                dto.likeCount(),
+                dto.depth(),
+                dto.createdAt(),
+                dto.isLiked(),
+                dto.deleted(),
+                AdminPostDetailResponse.toReplyResponses(dto.replies())
+        );
+    }
+}

--- a/admin-server/src/main/java/com/beta/controller/post/response/AdminPostDetailResponse.java
+++ b/admin-server/src/main/java/com/beta/controller/post/response/AdminPostDetailResponse.java
@@ -1,0 +1,161 @@
+package com.beta.controller.post.response;
+
+import com.beta.community.application.admin.dto.AdminPostDetailResult;
+import com.beta.community.domain.entity.Status;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "관리자 게시글 상세 응답")
+public record AdminPostDetailResponse(
+        Long postId,
+        String content,
+        String channel,
+        Status status,
+        List<ImageResponse> images,
+        List<String> hashtags,
+        AuthorInfo author,
+        EmotionCount emotions,
+        Integer commentCount,
+        LocalDateTime createdAt,
+        List<CommentResponse> comments,
+        boolean hasNextComments,
+        Long nextCommentCursor
+) {
+    public record ImageResponse(
+            Long imageId,
+            String imageUrl
+    ) {
+        static ImageResponse from(AdminPostDetailResult.ImageResult imageInfo) {
+            return new ImageResponse(
+                    imageInfo.imageId(),
+                    imageInfo.imageUrl()
+            );
+        }
+    }
+
+    public record AuthorInfo(
+            Long userId,
+            String nickname,
+            String teamCode
+    ) {
+    }
+
+    public record EmotionCount(
+            Integer likeCount,
+            Integer sadCount,
+            Integer funCount,
+            Integer hypeCount
+    ) {
+    }
+
+    public record CommentResponse(
+            Long commentId,
+            Long userId,
+            String nickname,
+            String teamCode,
+            String content,
+            Integer likeCount,
+            Integer depth,
+            LocalDateTime createdAt,
+            boolean isLiked,
+            boolean deleted,
+            List<ReplyResponse> replies
+    ) {
+    }
+
+    public record ReplyResponse(
+            Long commentId,
+            Long userId,
+            String nickname,
+            String teamCode,
+            String content,
+            Integer likeCount,
+            Integer depth,
+            LocalDateTime createdAt,
+            boolean isLiked,
+            boolean deleted
+    ) {
+    }
+
+    public static AdminPostDetailResponse from(AdminPostDetailResult dto) {
+        return new AdminPostDetailResponse(
+                dto.postId(),
+                dto.content(),
+                dto.channel().name(),
+                dto.status(),
+                dto.images().stream()
+                        .map(ImageResponse::from)
+                        .toList(),
+                dto.hashtags(),
+                new AuthorInfo(
+                        dto.author().userId(),
+                        dto.author().nickname(),
+                        dto.author().teamCode()
+                ),
+                new EmotionCount(
+                        dto.emotions().likeCount(),
+                        dto.emotions().sadCount(),
+                        dto.emotions().funCount(),
+                        dto.emotions().hypeCount()
+                ),
+                dto.commentCount(),
+                dto.createdAt(),
+                toCommentResponses(dto.comments()),
+                dto.hasNextComments(),
+                dto.nextCommentCursor()
+        );
+    }
+
+    static List<CommentResponse> toCommentResponses(List<AdminPostDetailResult.CommentResult> comments) {
+        if (comments == null) {
+            return List.of();
+        }
+
+        return comments.stream()
+                .map(AdminPostDetailResponse::toCommentResponse)
+                .toList();
+    }
+
+    static CommentResponse toCommentResponse(AdminPostDetailResult.CommentResult dto) {
+        return new CommentResponse(
+                dto.commentId(),
+                dto.userId(),
+                dto.nickname(),
+                dto.teamCode(),
+                dto.content(),
+                dto.likeCount(),
+                dto.depth(),
+                dto.createdAt(),
+                dto.isLiked(),
+                dto.deleted(),
+                toReplyResponses(dto.replies())
+        );
+    }
+
+    static List<ReplyResponse> toReplyResponses(List<AdminPostDetailResult.ReplyResult> replies) {
+        if (replies == null) {
+            return List.of();
+        }
+
+        return replies.stream()
+                .map(AdminPostDetailResponse::toReplyResponse)
+                .toList();
+    }
+
+    static ReplyResponse toReplyResponse(AdminPostDetailResult.ReplyResult dto) {
+        return new ReplyResponse(
+                dto.commentId(),
+                dto.userId(),
+                dto.nickname(),
+                dto.teamCode(),
+                dto.content(),
+                dto.likeCount(),
+                dto.depth(),
+                dto.createdAt(),
+                dto.isLiked(),
+                dto.deleted()
+        );
+    }
+}

--- a/admin-server/src/test/java/com/beta/controller/post/PostDetailControllerApiTest.java
+++ b/admin-server/src/test/java/com/beta/controller/post/PostDetailControllerApiTest.java
@@ -1,0 +1,221 @@
+package com.beta.controller.post;
+
+import com.beta.account.infra.client.apple.AppleLoginClient;
+import com.beta.community.infra.storage.OracleCloudStorageClient;
+import com.beta.core.response.ErrorResponse;
+import com.beta.core.security.AdminAuthConstants;
+import com.beta.core.security.JwtTokenProvider;
+import com.beta.docker.MysqlRedisTestContainer;
+import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.data.redis.username=",
+                "spring.data.redis.password=",
+                "management.health.mail.enabled=false"
+        }
+)
+@Sql(scripts = {"/sql/admin-post-cleanup.sql", "/sql/admin-post-detail-test-data.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/sql/admin-post-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class PostDetailControllerApiTest extends MysqlRedisTestContainer {
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    AppleLoginClient appleLoginClient;
+
+    @MockitoBean
+    JavaMailSender javaMailSender;
+
+    @MockitoBean
+    AbstractAuthenticationDetailsProvider authProvider;
+
+    @MockitoBean
+    ObjectStorage objectStorage;
+
+    @MockitoBean
+    OracleCloudStorageClient oracleCloudStorageClient;
+
+    @Test
+    void 관리자_게시글상세_조회시_200_응답과_게시글상세_내용을_반환한다() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(1L, null, "ADMIN", AdminAuthConstants.ADMIN_CLIENT);
+        HttpHeaders headers = bearerHeaders(accessToken);
+
+        // when
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/admin/posts/200",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                Map.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(toLong(response.getBody().get("postId"))).isEqualTo(200L);
+        assertThat(response.getBody().get("content")).isEqualTo("관리자 상세 조회용 게시글");
+        assertThat(response.getBody().get("channel")).isEqualTo("LG");
+        assertThat(response.getBody().get("status")).isEqualTo("ACTIVE");
+        assertThat(toInt(response.getBody().get("commentCount"))).isEqualTo(4);
+
+        Map<String, Object> author = toMap(response.getBody().get("author"));
+        assertThat(toLong(author.get("userId"))).isEqualTo(2L);
+        assertThat(author.get("nickname")).isEqualTo("slugger2");
+        assertThat(author.get("teamCode")).isEqualTo("LG");
+
+        List<Map<String, Object>> comments = toListOfMap(response.getBody().get("comments"));
+        assertThat(comments).hasSize(4);
+    }
+
+    @Test
+    void 관리자_게시글상세_조회는_차단상태와_무관하게_댓글을_반환한다() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(1L, null, "ADMIN", AdminAuthConstants.ADMIN_CLIENT);
+        HttpHeaders headers = bearerHeaders(accessToken);
+
+        // when
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/admin/posts/200",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                Map.class
+        );
+
+        // then
+        List<Map<String, Object>> comments = toListOfMap(response.getBody().get("comments"));
+        assertThat(comments)
+                .extracting(comment -> toLong(comment.get("commentId")))
+                .contains(203L);
+    }
+
+    @Test
+    void 관리자_게시글상세_조회는_숨김상태_게시글을_조회할수있다() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(1L, null, "ADMIN", AdminAuthConstants.ADMIN_CLIENT);
+        HttpHeaders headers = bearerHeaders(accessToken);
+
+        // when
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/admin/posts/201",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                Map.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(toLong(response.getBody().get("postId"))).isEqualTo(201L);
+        assertThat(response.getBody().get("content")).isEqualTo("숨김 처리된 게시글");
+        assertThat(response.getBody().get("status")).isEqualTo("HIDDEN");
+    }
+
+    @Test
+    void 관리자_게시글댓글_추가조회시_200_응답과_댓글페이지를_반환한다() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(1L, null, "ADMIN", AdminAuthConstants.ADMIN_CLIENT);
+        HttpHeaders headers = bearerHeaders(accessToken);
+
+        // when
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/admin/posts/200/comments?cursor=203",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                Map.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("hasNext")).isEqualTo(false);
+
+        List<Map<String, Object>> comments = toListOfMap(response.getBody().get("comments"));
+        assertThat(comments)
+                .extracting(comment -> toLong(comment.get("commentId")))
+                .containsExactly(202L, 201L);
+    }
+
+    @Test
+    void 관리자_게시글상세_API를_토큰없이_호출하면_401_JWT002_예외를_반환한다() {
+        // when
+        ResponseEntity<ErrorResponse> response = restTemplate.getForEntity(
+                "/api/v1/admin/posts/200",
+                ErrorResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("JWT002");
+    }
+
+    @Test
+    void CLIENT는_ADMIN이고_ROLE이_USER인_토큰으로_게시글상세를_호출하면_403_ADMIN001_예외를_반환한다() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(4L, null, "USER", AdminAuthConstants.ADMIN_CLIENT);
+        HttpHeaders headers = bearerHeaders(accessToken);
+
+        // when
+        ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                "/api/v1/admin/posts/200",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ErrorResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("ADMIN001");
+    }
+
+    HttpHeaders bearerHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        return headers;
+    }
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> toListOfMap(Object value) {
+        return ((List<Object>) value).stream()
+                .map(item -> (Map<String, Object>) item)
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> toMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    long toLong(Object value) {
+        return ((Number) value).longValue();
+    }
+
+    int toInt(Object value) {
+        return ((Number) value).intValue();
+    }
+}

--- a/admin-server/src/test/resources/sql/admin-post-detail-test-data.sql
+++ b/admin-server/src/test/resources/sql/admin-post-detail-test-data.sql
@@ -1,0 +1,111 @@
+DELETE FROM baseball_teams WHERE code IN ('LG', 'KIA');
+
+INSERT INTO baseball_teams (
+    code,
+    team_name_kr,
+    team_name_en,
+    home_stadium,
+    stadium_address
+) VALUES
+    ('LG', 'LG 트윈스', 'LG Twins', '잠실야구장', '서울시 송파구'),
+    ('KIA', 'KIA 타이거즈', 'KIA Tigers', '광주-기아 챔피언스 필드', '광주광역시 북구');
+
+INSERT INTO users (
+    id,
+    social_id,
+    email,
+    nickname,
+    social_provider,
+    status,
+    role,
+    signup_step,
+    favorite_team_code,
+    created_at,
+    updated_at
+) VALUES
+    (1, 'admin-social-id', 'admin@test.com', 'admin-user', 'KAKAO', 'ACTIVE', 'ADMIN', 'COMPLETED', 'LG', NOW(), NOW()),
+    (2, 'author-social-id-2', 'author2@test.com', 'slugger2', 'KAKAO', 'ACTIVE', 'USER', 'COMPLETED', 'LG', NOW(), NOW()),
+    (3, 'author-social-id-3', 'author3@test.com', 'slugger3', 'KAKAO', 'ACTIVE', 'USER', 'COMPLETED', 'KIA', NOW(), NOW()),
+    (4, 'normal-user-social-id', 'user4@test.com', 'user4', 'KAKAO', 'ACTIVE', 'USER', 'COMPLETED', 'LG', NOW(), NOW());
+
+INSERT INTO hashtag (
+    id,
+    tag_name,
+    usage_count,
+    created_at,
+    updated_at
+) VALUES
+    (1, '관리자', 1, NOW(), NOW()),
+    (2, '상세', 1, NOW(), NOW());
+
+INSERT INTO posts (
+    id,
+    user_id,
+    content,
+    channel,
+    status,
+    comment_count,
+    like_count,
+    sad_count,
+    fun_count,
+    hype_count,
+    deleted_at,
+    created_at,
+    updated_at
+) VALUES
+    (200, 2, '관리자 상세 조회용 게시글', 'LG', 'ACTIVE', 4, 11, 2, 3, 4, NULL, '2026-04-01 10:00:00', NOW()),
+    (201, 3, '숨김 처리된 게시글', 'KIA', 'HIDDEN', 0, 0, 0, 0, 0, NULL, '2026-04-01 11:00:00', NOW());
+
+INSERT INTO post_image (
+    id,
+    post_id,
+    user_id,
+    img_url,
+    origin_name,
+    new_name,
+    sort,
+    file_size,
+    mime_type,
+    status,
+    created_at,
+    updated_at
+) VALUES
+    (1, 200, 2, 'https://storage.example.com/images/admin-post-200-1.jpg', 'post200_1.jpg', 'uuid-post200-1.jpg', 0, 102400, 'image/jpeg', 'ACTIVE', NOW(), NOW()),
+    (2, 200, 2, 'https://storage.example.com/images/admin-post-200-2.jpg', 'post200_2.jpg', 'uuid-post200-2.jpg', 1, 204800, 'image/jpeg', 'ACTIVE', NOW(), NOW());
+
+INSERT INTO post_hashtag (
+    id,
+    post_id,
+    hashtag_id,
+    created_at,
+    updated_at
+) VALUES
+    (1, 200, 1, NOW(), NOW()),
+    (2, 200, 2, NOW(), NOW());
+
+INSERT INTO comment (
+    id,
+    post_id,
+    user_id,
+    parent_id,
+    content,
+    depth,
+    like_count,
+    status,
+    created_at,
+    updated_at
+) VALUES
+    (201, 200, 2, NULL, '첫 번째 댓글', 0, 3, 'ACTIVE', '2026-04-01 10:01:00', NOW()),
+    (202, 200, 2, NULL, '두 번째 댓글', 0, 2, 'ACTIVE', '2026-04-01 10:02:00', NOW()),
+    (203, 200, 3, NULL, '관리자 개인 차단과 무관하게 보여야 하는 댓글', 0, 1, 'ACTIVE', '2026-04-01 10:03:00', NOW()),
+    (204, 200, 2, NULL, '삭제된 댓글', 0, 0, 'DELETED', '2026-04-01 10:04:00', NOW()),
+    (301, 200, 3, 203, '차단 사용자 답글', 1, 0, 'ACTIVE', '2026-04-01 10:05:00', NOW());
+
+INSERT INTO user_block (
+    id,
+    blocker_id,
+    blocked_id,
+    created_at,
+    updated_at
+) VALUES
+    (1, 1, 3, NOW(), NOW());

--- a/module-account/src/test/java/com/beta/account/domain/service/UserStatusServiceTest.java
+++ b/module-account/src/test/java/com/beta/account/domain/service/UserStatusServiceTest.java
@@ -70,7 +70,7 @@ class UserStatusServiceTest {
         // when & then
         assertThatThrownBy(() -> userStatusService.validateUserStatus(user))
                 .isInstanceOf(UserSuspendedException.class)
-                .hasMessage("정지된 사용자입니다. 관리자에게 문의 하세요.")
+                .hasMessageContaining("정지된 사용자입니다")
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_SUSPENDED);
     }

--- a/module-community/src/main/java/com/beta/community/application/admin/AdminPostDetailAppService.java
+++ b/module-community/src/main/java/com/beta/community/application/admin/AdminPostDetailAppService.java
@@ -1,0 +1,239 @@
+package com.beta.community.application.admin;
+
+import com.beta.community.application.admin.dto.AdminPostCommentsResult;
+import com.beta.community.application.admin.dto.AdminPostDetailResult;
+import com.beta.community.domain.entity.Comment;
+import com.beta.community.domain.entity.Post;
+import com.beta.community.domain.entity.PostHashtag;
+import com.beta.community.domain.entity.PostImage;
+import com.beta.community.domain.entity.Status;
+import com.beta.community.domain.service.CommentReadService;
+import com.beta.community.domain.service.PostReadService;
+import com.beta.community.infra.repository.PostHashtagJpaRepository;
+import com.beta.community.infra.repository.PostImageJpaRepository;
+import com.beta.core.port.UserPort;
+import com.beta.core.port.dto.AuthorInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPostDetailAppService {
+
+    private static final int COMMENT_PAGE_SIZE = 20;
+
+    private final PostReadService postReadService;
+    private final CommentReadService commentReadService;
+    private final PostImageJpaRepository postImageJpaRepository;
+    private final PostHashtagJpaRepository postHashtagJpaRepository;
+    private final UserPort userPort;
+
+    @Transactional(readOnly = true)
+    public AdminPostDetailResult getPostDetail(Long postId) {
+        Post post = postReadService.findById(postId);
+
+        List<AdminPostDetailResult.ImageResult> images = getImagesMap(List.of(postId)).getOrDefault(postId, List.of());
+        List<String> hashtags = getHashtagsMap(List.of(postId)).getOrDefault(postId, List.of());
+
+        AdminCommentPage commentPage = fetchCommentsWithTree(postId, null);
+
+        List<Long> allUserIds = Stream.concat(
+                        Stream.of(post.getUserId()),
+                        commentPage.allComments().stream().map(Comment::getUserId)
+                )
+                .distinct()
+                .toList();
+        Map<Long, AuthorInfo> authorMap = userPort.findAuthorsByIds(allUserIds);
+
+        List<AdminPostDetailResult.CommentResult> comments = buildCommentTree(
+                commentPage.parentComments(),
+                commentPage.replies(),
+                authorMap
+        );
+
+        AuthorInfo postAuthor = authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId()));
+
+        return AdminPostDetailResult.builder()
+                .postId(post.getId())
+                .author(AdminPostDetailResult.AuthorResult.builder()
+                        .userId(postAuthor.getUserId())
+                        .nickname(postAuthor.getNickname())
+                        .teamCode(postAuthor.getTeamCode())
+                        .build())
+                .content(post.getContent())
+                .channel(post.getChannel())
+                .status(post.getStatus())
+                .images(images)
+                .hashtags(hashtags)
+                .emotions(AdminPostDetailResult.EmotionResult.builder()
+                        .likeCount(post.getLikeCount())
+                        .sadCount(post.getSadCount())
+                        .funCount(post.getFunCount())
+                        .hypeCount(post.getHypeCount())
+                        .build())
+                .commentCount(post.getCommentCount())
+                .createdAt(post.getCreatedAt())
+                .comments(comments)
+                .hasNextComments(commentPage.hasNext())
+                .nextCommentCursor(commentPage.nextCursor())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminPostCommentsResult getComments(Long postId, Long cursor) {
+        postReadService.findById(postId);
+
+        AdminCommentPage commentPage = fetchCommentsWithTree(postId, cursor);
+
+        List<Long> userIds = commentPage.allComments().stream()
+                .map(Comment::getUserId)
+                .distinct()
+                .toList();
+        Map<Long, AuthorInfo> authorMap = userPort.findAuthorsByIds(userIds);
+
+        List<AdminPostDetailResult.CommentResult> comments = buildCommentTree(
+                commentPage.parentComments(),
+                commentPage.replies(),
+                authorMap
+        );
+
+        return AdminPostCommentsResult.builder()
+                .comments(comments)
+                .hasNext(commentPage.hasNext())
+                .nextCursor(commentPage.nextCursor())
+                .build();
+    }
+
+    private AdminCommentPage fetchCommentsWithTree(Long postId, Long cursor) {
+        List<Comment> parentComments = commentReadService.findParentComments(postId, cursor, COMMENT_PAGE_SIZE + 1);
+        boolean hasNext = parentComments.size() > COMMENT_PAGE_SIZE;
+        if (hasNext) {
+            parentComments = parentComments.subList(0, COMMENT_PAGE_SIZE);
+        }
+
+        Long nextCursor = hasNext && !parentComments.isEmpty()
+                ? parentComments.getLast().getId()
+                : null;
+
+        List<Long> parentIds = parentComments.stream().map(Comment::getId).toList();
+        List<Comment> replies = commentReadService.findRepliesByParentIds(postId, parentIds);
+        List<Comment> allComments = Stream.concat(parentComments.stream(), replies.stream()).toList();
+
+        return new AdminCommentPage(parentComments, replies, allComments, hasNext, nextCursor);
+    }
+
+    private List<AdminPostDetailResult.CommentResult> buildCommentTree(
+            List<Comment> parentComments,
+            List<Comment> replies,
+            Map<Long, AuthorInfo> authorMap
+    ) {
+        Map<Long, List<Comment>> repliesMap = replies.stream()
+                .collect(Collectors.groupingBy(Comment::getParentId));
+
+        return parentComments.stream()
+                .map(parent -> buildCommentDto(
+                        parent,
+                        authorMap,
+                        parent.getStatus() == Status.DELETED,
+                        repliesMap.getOrDefault(parent.getId(), List.of()).stream()
+                                .map(reply -> buildReplyDto(
+                                        reply,
+                                        authorMap,
+                                        reply.getStatus() == Status.DELETED
+                                ))
+                                .toList()
+                ))
+                .toList();
+    }
+
+    private AdminPostDetailResult.CommentResult buildCommentDto(
+            Comment comment,
+            Map<Long, AuthorInfo> authorMap,
+            boolean deleted,
+            List<AdminPostDetailResult.ReplyResult> replies
+    ) {
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+
+        return AdminPostDetailResult.CommentResult.builder()
+                .commentId(comment.getId())
+                .userId(deleted ? null : comment.getUserId())
+                .nickname(deleted ? null : author.getNickname())
+                .teamCode(deleted ? null : author.getTeamCode())
+                .content(deleted ? "삭제된 댓글입니다" : comment.getContent())
+                .likeCount(deleted ? 0 : comment.getLikeCount())
+                .depth(comment.getDepth())
+                .createdAt(comment.getCreatedAt())
+                .liked(false)
+                .deleted(deleted)
+                .replies(replies)
+                .build();
+    }
+
+    private AdminPostDetailResult.ReplyResult buildReplyDto(
+            Comment comment,
+            Map<Long, AuthorInfo> authorMap,
+            boolean deleted
+    ) {
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+
+        return AdminPostDetailResult.ReplyResult.builder()
+                .commentId(comment.getId())
+                .userId(deleted ? null : comment.getUserId())
+                .nickname(deleted ? null : author.getNickname())
+                .teamCode(deleted ? null : author.getTeamCode())
+                .content(deleted ? "삭제된 댓글입니다" : comment.getContent())
+                .likeCount(deleted ? 0 : comment.getLikeCount())
+                .depth(comment.getDepth())
+                .createdAt(comment.getCreatedAt())
+                .liked(false)
+                .deleted(deleted)
+                .build();
+    }
+
+    private Map<Long, List<AdminPostDetailResult.ImageResult>> getImagesMap(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PostImage> images = postImageJpaRepository.findByPostIdInAndStatusOrderByPostIdAscSortAsc(postIds, Status.ACTIVE);
+        return images.stream()
+                .collect(Collectors.groupingBy(
+                        PostImage::getPostId,
+                        Collectors.mapping(
+                                image -> AdminPostDetailResult.ImageResult.builder()
+                                        .imageId(image.getId())
+                                        .imageUrl(image.getImgUrl())
+                                        .build(),
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    private Map<Long, List<String>> getHashtagsMap(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PostHashtag> postHashtags = postHashtagJpaRepository.findByPost_IdIn(postIds);
+        return postHashtags.stream()
+                .collect(Collectors.groupingBy(
+                        postHashtag -> postHashtag.getPost().getId(),
+                        Collectors.mapping(postHashtag -> postHashtag.getHashtag().getTagName(), Collectors.toList())
+                ));
+    }
+
+    private record AdminCommentPage(
+            List<Comment> parentComments,
+            List<Comment> replies,
+            List<Comment> allComments,
+            boolean hasNext,
+            Long nextCursor
+    ) {
+    }
+}

--- a/module-community/src/main/java/com/beta/community/application/admin/AdminPostDetailFacadeService.java
+++ b/module-community/src/main/java/com/beta/community/application/admin/AdminPostDetailFacadeService.java
@@ -1,0 +1,239 @@
+package com.beta.community.application.admin;
+
+import com.beta.community.application.admin.dto.AdminPostCommentsResult;
+import com.beta.community.application.admin.dto.AdminPostDetailResult;
+import com.beta.community.domain.entity.Comment;
+import com.beta.community.domain.entity.Post;
+import com.beta.community.domain.entity.PostHashtag;
+import com.beta.community.domain.entity.PostImage;
+import com.beta.community.domain.entity.Status;
+import com.beta.community.domain.service.CommentReadService;
+import com.beta.community.domain.service.PostReadService;
+import com.beta.community.infra.repository.PostHashtagJpaRepository;
+import com.beta.community.infra.repository.PostImageJpaRepository;
+import com.beta.core.port.UserPort;
+import com.beta.core.port.dto.AuthorInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPostDetailFacadeService {
+
+    private static final int COMMENT_PAGE_SIZE = 20;
+
+    private final PostReadService postReadService;
+    private final CommentReadService commentReadService;
+    private final PostImageJpaRepository postImageJpaRepository;
+    private final PostHashtagJpaRepository postHashtagJpaRepository;
+    private final UserPort userPort;
+
+    @Transactional(readOnly = true)
+    public AdminPostDetailResult getPostDetail(Long postId) {
+        Post post = postReadService.findById(postId);
+
+        List<AdminPostDetailResult.ImageResult> images = getImagesMap(List.of(postId)).getOrDefault(postId, List.of());
+        List<String> hashtags = getHashtagsMap(List.of(postId)).getOrDefault(postId, List.of());
+
+        AdminCommentPage commentPage = fetchCommentsWithTree(postId, null);
+
+        List<Long> allUserIds = Stream.concat(
+                        Stream.of(post.getUserId()),
+                        commentPage.allComments().stream().map(Comment::getUserId)
+                )
+                .distinct()
+                .toList();
+        Map<Long, AuthorInfo> authorMap = userPort.findAuthorsByIds(allUserIds);
+
+        List<AdminPostDetailResult.CommentResult> comments = buildCommentTree(
+                commentPage.parentComments(),
+                commentPage.replies(),
+                authorMap
+        );
+
+        AuthorInfo postAuthor = authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId()));
+
+        return new AdminPostDetailResult(
+                post.getId(),
+                new AdminPostDetailResult.AuthorResult(
+                        postAuthor.getUserId(),
+                        postAuthor.getNickname(),
+                        postAuthor.getTeamCode()
+                ),
+                post.getContent(),
+                post.getChannel(),
+                post.getStatus(),
+                images,
+                hashtags,
+                new AdminPostDetailResult.EmotionResult(
+                        post.getLikeCount(),
+                        post.getSadCount(),
+                        post.getFunCount(),
+                        post.getHypeCount()
+                ),
+                post.getCommentCount(),
+                post.getCreatedAt(),
+                comments,
+                commentPage.hasNext(),
+                commentPage.nextCursor()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public AdminPostCommentsResult getComments(Long postId, Long cursor) {
+        postReadService.findById(postId);
+
+        AdminCommentPage commentPage = fetchCommentsWithTree(postId, cursor);
+
+        List<Long> userIds = commentPage.allComments().stream()
+                .map(Comment::getUserId)
+                .distinct()
+                .toList();
+        Map<Long, AuthorInfo> authorMap = userPort.findAuthorsByIds(userIds);
+
+        List<AdminPostDetailResult.CommentResult> comments = buildCommentTree(
+                commentPage.parentComments(),
+                commentPage.replies(),
+                authorMap
+        );
+
+        return new AdminPostCommentsResult(
+                comments,
+                commentPage.hasNext(),
+                commentPage.nextCursor()
+        );
+    }
+
+    private AdminCommentPage fetchCommentsWithTree(Long postId, Long cursor) {
+        List<Comment> parentComments = commentReadService.findParentComments(postId, cursor, COMMENT_PAGE_SIZE + 1);
+        boolean hasNext = parentComments.size() > COMMENT_PAGE_SIZE;
+        if (hasNext) {
+            parentComments = parentComments.subList(0, COMMENT_PAGE_SIZE);
+        }
+
+        Long nextCursor = hasNext && !parentComments.isEmpty()
+                ? parentComments.getLast().getId()
+                : null;
+
+        List<Long> parentIds = parentComments.stream().map(Comment::getId).toList();
+        List<Comment> replies = commentReadService.findRepliesByParentIds(postId, parentIds);
+        List<Comment> allComments = Stream.concat(parentComments.stream(), replies.stream()).toList();
+
+        return new AdminCommentPage(parentComments, replies, allComments, hasNext, nextCursor);
+    }
+
+    private List<AdminPostDetailResult.CommentResult> buildCommentTree(
+            List<Comment> parentComments,
+            List<Comment> replies,
+            Map<Long, AuthorInfo> authorMap
+    ) {
+        Map<Long, List<Comment>> repliesMap = replies.stream()
+                .collect(Collectors.groupingBy(Comment::getParentId));
+
+        return parentComments.stream()
+                .map(parent -> buildCommentDto(
+                        parent,
+                        authorMap,
+                        parent.getStatus() == Status.DELETED,
+                        repliesMap.getOrDefault(parent.getId(), List.of()).stream()
+                                .map(reply -> buildReplyDto(
+                                        reply,
+                                        authorMap,
+                                        reply.getStatus() == Status.DELETED
+                                ))
+                                .toList()
+                ))
+                .toList();
+    }
+
+    private AdminPostDetailResult.CommentResult buildCommentDto(
+            Comment comment,
+            Map<Long, AuthorInfo> authorMap,
+            boolean deleted,
+            List<AdminPostDetailResult.ReplyResult> replies
+    ) {
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+
+        return new AdminPostDetailResult.CommentResult(
+                comment.getId(),
+                deleted ? null : comment.getUserId(),
+                deleted ? null : author.getNickname(),
+                deleted ? null : author.getTeamCode(),
+                deleted ? "삭제된 댓글입니다" : comment.getContent(),
+                deleted ? 0 : comment.getLikeCount(),
+                comment.getDepth(),
+                comment.getCreatedAt(),
+                false,
+                deleted,
+                replies
+        );
+    }
+
+    private AdminPostDetailResult.ReplyResult buildReplyDto(
+            Comment comment,
+            Map<Long, AuthorInfo> authorMap,
+            boolean deleted
+    ) {
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+
+        return new AdminPostDetailResult.ReplyResult(
+                comment.getId(),
+                deleted ? null : comment.getUserId(),
+                deleted ? null : author.getNickname(),
+                deleted ? null : author.getTeamCode(),
+                deleted ? "삭제된 댓글입니다" : comment.getContent(),
+                deleted ? 0 : comment.getLikeCount(),
+                comment.getDepth(),
+                comment.getCreatedAt(),
+                false,
+                deleted
+        );
+    }
+
+    private Map<Long, List<AdminPostDetailResult.ImageResult>> getImagesMap(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PostImage> images = postImageJpaRepository.findByPostIdInAndStatusOrderByPostIdAscSortAsc(postIds, Status.ACTIVE);
+        return images.stream()
+                .collect(Collectors.groupingBy(
+                        PostImage::getPostId,
+                        Collectors.mapping(
+                                image -> new AdminPostDetailResult.ImageResult(
+                                        image.getId(),
+                                        image.getImgUrl()
+                                ),
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    private Map<Long, List<String>> getHashtagsMap(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PostHashtag> postHashtags = postHashtagJpaRepository.findByPost_IdIn(postIds);
+        return postHashtags.stream()
+                .collect(Collectors.groupingBy(
+                        postHashtag -> postHashtag.getPost().getId(),
+                        Collectors.mapping(postHashtag -> postHashtag.getHashtag().getTagName(), Collectors.toList())
+                ));
+    }
+
+    private record AdminCommentPage(
+            List<Comment> parentComments,
+            List<Comment> replies,
+            List<Comment> allComments,
+            boolean hasNext,
+            Long nextCursor
+    ) {
+    }
+}

--- a/module-community/src/main/java/com/beta/community/application/admin/dto/AdminPostCommentsResult.java
+++ b/module-community/src/main/java/com/beta/community/application/admin/dto/AdminPostCommentsResult.java
@@ -1,0 +1,10 @@
+package com.beta.community.application.admin.dto;
+
+import java.util.List;
+
+public record AdminPostCommentsResult(
+        List<AdminPostDetailResult.CommentResult> comments,
+        boolean hasNext,
+        Long nextCursor
+) {
+}

--- a/module-community/src/main/java/com/beta/community/application/admin/dto/AdminPostDetailResult.java
+++ b/module-community/src/main/java/com/beta/community/application/admin/dto/AdminPostDetailResult.java
@@ -1,0 +1,73 @@
+package com.beta.community.application.admin.dto;
+
+import com.beta.community.domain.entity.Post;
+import com.beta.community.domain.entity.Status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminPostDetailResult(
+        Long postId,
+        AuthorResult author,
+        String content,
+        Post.Channel channel,
+        Status status,
+        List<ImageResult> images,
+        List<String> hashtags,
+        EmotionResult emotions,
+        Integer commentCount,
+        LocalDateTime createdAt,
+        List<CommentResult> comments,
+        boolean hasNextComments,
+        Long nextCommentCursor
+) {
+    public record AuthorResult(
+            Long userId,
+            String nickname,
+            String teamCode
+    ) {
+    }
+
+    public record ImageResult(
+            Long imageId,
+            String imageUrl
+    ) {
+    }
+
+    public record EmotionResult(
+            Integer likeCount,
+            Integer sadCount,
+            Integer funCount,
+            Integer hypeCount
+    ) {
+    }
+
+    public record CommentResult(
+            Long commentId,
+            Long userId,
+            String nickname,
+            String teamCode,
+            String content,
+            Integer likeCount,
+            Integer depth,
+            LocalDateTime createdAt,
+            boolean isLiked,
+            boolean deleted,
+            List<ReplyResult> replies
+    ) {
+    }
+
+    public record ReplyResult(
+            Long commentId,
+            Long userId,
+            String nickname,
+            String teamCode,
+            String content,
+            Integer likeCount,
+            Integer depth,
+            LocalDateTime createdAt,
+            boolean isLiked,
+            boolean deleted
+    ) {
+    }
+}


### PR DESCRIPTION
## PR Title

#### admin / 관리자 게시글 상세 조회 API 및 댓글 페이징 API 추가

---

## What (작업 내용)

bd1d7ca, 46b9168
- 관리자 게시글 상세 조회 API `GET /api/v1/admin/posts/{postId}` 를 추가했습니다.
- 관리자 게시글 댓글 추가 조회 API `GET /api/v1/admin/posts/{postId}/comments` 를 추가했습니다.
- `module-community`의 `application/admin` 아래 `AdminPostDetailFacadeService`를 추가했습니다.
- 관리자 게시글 상세/댓글 조회 API 통합 테스트 코드를 추가했습니다.

---

## Key Points (중점 사항)

- 관리자 게시글 상세 조회는 `ACTIVE`만이 아니라 `HIDDEN`, `DELETED`, `REPORTED` 상태 게시글도 조회할 수 있습니다.
- 상세 첫 조회에서는 게시글 정보와 댓글 첫 페이지를 함께 반환하고 이후 댓글은 별도 API로 커서 기반 페이징 조회합니다.
- 관리자 전용 조합 로직은 `module-community.application.admin`에 두고, 도메인 이하 레이어는 기존 메서드를 그대로 재사용합니다.
- `module-community` 내부에서는 계정 모듈을 직접 참조하지 않고 `UserPort`를 통해 작성자 정보를 조회합니다.
- 사용자용 상세 DTO/서비스 흐름은 그대로 유지되어 기존 사용자 API 동작에 영향이 없도록 했습니다.

---

## Additional Notes (기타 참고사항)

- 정지 사용자 예외 메시지 변경으로 인해 깨지는 테스트의 검증내용을 수정했습니다. 37dc9b5
- 사용하지 않는 `App Service` 를 삭제하지 않고 `Facade Service` 와 같이 커밋하여(bd1d7ca) 삭제했습니다.

---

## Related Issues
- Ref #66