### PR TITLE
search / Logstash 증분 동기화 쿼리 최적화 및 해시태그 변경 동기화 보완

### DIFF
--- a/module-community/src/main/java/com/beta/community/domain/service/HashtagService.java
+++ b/module-community/src/main/java/com/beta/community/domain/service/HashtagService.java
@@ -73,11 +73,12 @@ public class HashtagService {
                 .filter(t -> !existingTagNames.contains(t))
                 .toList();
 
+        boolean hashtagsChanged = !toRemove.isEmpty() || !toAdd.isEmpty();
+
         if (!toRemove.isEmpty()) {
             List<Hashtag> removeHashtags = hashtagJpaRepository.findByTagNameIn(toRemove);
             postHashtagJpaRepository.deleteAllByPostIdAndHashtagIn(post.getId(), removeHashtags);
             hashtagJpaRepository.decrementUsageCountByTagNames(toRemove);
-            postJpaRepository.touchUpdatedAt(post.getId());
         }
 
         if (!toAdd.isEmpty()) {
@@ -92,6 +93,10 @@ public class HashtagService {
                             .build())
                     .toList();
             postHashtagJpaRepository.saveAll(newPostHashtags);
+        }
+
+        if (hashtagsChanged) {
+            postJpaRepository.touchUpdatedAt(post.getId());
         }
 
         return newValidNames;

--- a/module-community/src/test/java/com/beta/community/domain/service/HashtagServiceTest.java
+++ b/module-community/src/test/java/com/beta/community/domain/service/HashtagServiceTest.java
@@ -150,6 +150,25 @@ class HashtagServiceTest {
             verify(hashtagJpaRepository).decrementUsageCountByTagNames(List.of("야구"));
             verify(postJpaRepository).touchUpdatedAt(1L);
         }
+
+        @Test
+        @DisplayName("해시태그 추가 시 post.updatedAt을 갱신")
+        void touchPostUpdatedAt_whenHashtagAdded() {
+            Post post = mock(Post.class);
+            given(post.getId()).willReturn(1L);
+            given(postHashtagJpaRepository.findByPostId(1L)).willReturn(List.of());
+
+            Hashtag addedHashtag = createHashtag(2L, "두산");
+            given(hashtagJpaRepository.findByTagNameIn(List.of("두산"))).willReturn(List.of(addedHashtag));
+
+            List<String> result = hashtagService.updateHashtags(post, List.of("두산"));
+
+            assertThat(result).containsExactly("두산");
+            verify(hashtagJpaRepository).insertIgnore("두산");
+            verify(hashtagJpaRepository).incrementUsageCountByTagNames(List.of("두산"));
+            verify(postHashtagJpaRepository).saveAll(anyList());
+            verify(postJpaRepository).touchUpdatedAt(1L);
+        }
     }
 
     private Hashtag createHashtag(Long id, String tagName) {

--- a/module-core/src/testFixtures/resources/logstash/hashtags.conf
+++ b/module-core/src/testFixtures/resources/logstash/hashtags.conf
@@ -15,7 +15,7 @@ input {
         CASE WHEN h.usage_count > 0 THEN 'index' ELSE 'delete' END AS es_action,
         h.updated_at AS sync_updated_at
       FROM hashtag h
-      WHERE h.updated_at > DATE_SUB(:sql_last_value, INTERVAL 3 SECOND)
+      WHERE h.updated_at > DATE_SUB(:sql_last_value, INTERVAL 2 SECOND)
       ORDER BY h.updated_at ASC, h.id ASC
     "
     use_column_value => true

--- a/module-core/src/testFixtures/resources/logstash/posts.conf
+++ b/module-core/src/testFixtures/resources/logstash/posts.conf
@@ -8,30 +8,23 @@ input {
     lowercase_column_names => false
     schedule => "*/5 * * * * *"
     statement => "
-      SELECT * FROM (
-        SELECT
-          p.id,
-          p.channel,
-          p.content,
-          u.nickname AS authorNickname,
-          COALESCE(GROUP_CONCAT(DISTINCT h.tag_name ORDER BY h.tag_name SEPARATOR ','), '') AS hashtags_csv,
-          p.created_at AS createdAt,
-          (p.comment_count * 4 + p.like_count + p.sad_count + p.fun_count + p.hype_count) AS popularityScore,
-          CASE WHEN p.status = 'ACTIVE' AND p.deleted_at IS NULL THEN 'index' ELSE 'delete' END AS es_action,
-          GREATEST(
-            p.updated_at,
-            COALESCE(u.updated_at, TIMESTAMP('1970-01-01 00:00:00')),
-            COALESCE(MAX(ph.updated_at), TIMESTAMP('1970-01-01 00:00:00')),
-            COALESCE(MAX(h.updated_at), TIMESTAMP('1970-01-01 00:00:00'))
-          ) AS sync_updated_at
-        FROM posts p
-        LEFT JOIN users u ON u.id = p.user_id
-        LEFT JOIN post_hashtag ph ON ph.post_id = p.id
-        LEFT JOIN hashtag h ON h.id = ph.hashtag_id
-        GROUP BY p.id, p.channel, p.content, u.nickname, p.created_at, p.comment_count, p.like_count, p.sad_count, p.fun_count, p.hype_count, p.status, p.deleted_at, p.updated_at, u.updated_at
-      ) t
-      WHERE t.sync_updated_at > DATE_SUB(:sql_last_value, INTERVAL 3 SECOND)
-      ORDER BY t.sync_updated_at ASC, t.id ASC
+      SELECT
+        p.id,
+        p.channel,
+        p.content,
+        u.nickname AS authorNickname,
+        COALESCE(GROUP_CONCAT(DISTINCT h.tag_name ORDER BY h.tag_name SEPARATOR ','), '') AS hashtags_csv,
+        p.created_at AS createdAt,
+        (p.comment_count * 4 + p.like_count + p.sad_count + p.fun_count + p.hype_count) AS popularityScore,
+        CASE WHEN p.status = 'ACTIVE' AND p.deleted_at IS NULL THEN 'index' ELSE 'delete' END AS es_action,
+        p.updated_at AS sync_updated_at
+      FROM posts p
+      LEFT JOIN users u ON u.id = p.user_id
+      LEFT JOIN post_hashtag ph ON ph.post_id = p.id
+      LEFT JOIN hashtag h ON h.id = ph.hashtag_id
+      WHERE p.updated_at > DATE_SUB(:sql_last_value, INTERVAL 2 SECOND)
+      GROUP BY p.id, p.channel, p.content, u.nickname, p.created_at, p.comment_count, p.like_count, p.sad_count, p.fun_count, p.hype_count, p.status, p.deleted_at, p.updated_at
+      ORDER BY p.updated_at ASC, p.id ASC
     "
     use_column_value => true
     tracking_column => "sync_updated_at"

--- a/module-core/src/testFixtures/resources/logstash/users.conf
+++ b/module-core/src/testFixtures/resources/logstash/users.conf
@@ -18,7 +18,7 @@ input {
         u.updated_at AS sync_updated_at
       FROM users u
       LEFT JOIN baseball_teams bt ON bt.code = u.favorite_team_code
-      WHERE u.updated_at > DATE_SUB(:sql_last_value, INTERVAL 3 SECOND)
+      WHERE u.updated_at > DATE_SUB(:sql_last_value, INTERVAL 2 SECOND)
       ORDER BY u.updated_at ASC, u.id ASC
     "
     use_column_value => true


### PR DESCRIPTION
## PR Title
#### Logstash 증분 동기화 쿼리 최적화 및 해시태그 변경 동기화 보완

---

## What (작업 내용)

f9c3136

- 해시태그 추가 시에도 `posts.updated_at` 기반 증분 동기화 흐름에 포함되도록 변경했습니다.

aba36cf

- 게시글, 해시태그, 반응 수 변경 시 `posts.updated_at`이 갱신되도록 한 백엔드 로직 변경에 맞춰서
  `posts` 파이프라인의 증분 추적 기준을 `posts.updated_at`으로 일원화했습니다.

- `users`, `hashtags`, `posts` 증분 조회 성능 개선을 위해 `(updated_at, id)` 복합 인덱스를 적용했습니다.

- 운영 Logstash 증분 동기화 polling 주기를 `60초 -> 5초`로 단축해 검색 반영 지연을 줄였습니다.

 > Logstash fixture 파일은 `5초` 지만, 실제 운영 환경은 `60초`로 설정해 두어서 조정했습니다.

- polling 주기 단축에 맞춰 overlap 구간을 `3초 -> 2초`로 조정했습니다.

---

## Key Points (중점 사항)

운영 환경에서 Logstash 증분 동기화 polling 주기 `60초`는 검색 반영 지연이 크다고 판단해
polling 주기를 더 짧게 가져갈 수 있도록 기존 증분 조회 쿼리와 실행 계획을 확인했습니다.

기존 `users`, `hashtags`, `posts` 증분 조회 쿼리의 실행 계획을 확인한 결과
`updated_at`, `id` 기반 증분 조회 패턴에 맞는 인덱스가 없어 `EXPLAIN` 상 `table full scan`이 발생하고 있었습니다.

또한 백엔드에서는 게시글 검색 문서에 영향을 주는 변경이 발생할 때 `posts.updated_at`이 갱신되도록 로직이 변경되었지만 
`posts` 파이프라인은 이를 기준으로 추적하지 않고 기존 증분 조회 방식이 유지되고 있었습니다.

이에 따라 `posts` 증분 추적 기준을 `posts.updated_at`으로 정리하고
`users`, `hashtags`, `posts`에 `(updated_at, id)` 복합 인덱스를 적용해 증분 조회 비용을 줄이도록 보완했습니다.

### 증분 조회 성능 개선 및 실행 계획 비교

<details>
<summary><strong>Users</strong></summary>

#### 증분 조회 SQL

```sql
SELECT
  u.id,
  u.nickname,
  u.bio,
  u.favorite_team_code AS teamCode,
  bt.team_name_kr AS teamNameKr,
  CASE WHEN u.status = 'ACTIVE' THEN 'index' ELSE 'delete' END AS es_action,
  u.updated_at AS sync_updated_at
FROM users u
LEFT JOIN baseball_teams bt ON bt.code = u.favorite_team_code
WHERE u.updated_at > DATE_SUB(:sql_last_value, INTERVAL 2 SECOND)
ORDER BY u.updated_at ASC, u.id ASC
```

#### 복합 인덱스 추가(updated_at, id)

`users` 증분 조회는 `WHERE u.updated_at > ...` 조건으로 대상을 조회하고,
`ORDER BY u.updated_at, u.id` 기준으로 정렬하는 쿼리입니다.

기존에는 `updated_at` 관련 인덱스가 없어 EXPLAIN 상 table full scan이 발생하고 있었습니다.

`updated_at`와 `id`에 단일 인덱스를 각각 두기보다
MySQL 복합 인덱스의 선두 컬럼 매칭(`leftmost prefix rule`)을 고려해  
`updated_at` 조건 조회와 `updated_at, id` 정렬을 함께 처리할 수 있도록 `(updated_at, id)` 복합 인덱스를 추가했습니다.

인덱스 추가 후에는 EXPLAIN 상 index range scan으로 변경된 것을 확인했습니다.

#### 변경 전 EXPLAIN

<img width="902" height="142" alt="동기화-변경전-user" src="https://github.com/user-attachments/assets/b5171a72-4771-4ff8-8301-96533ff27010" />

#### 변경 후 EXPLAIN

<img width="1800" height="140" alt="동기화-변경후-user" src="https://github.com/user-attachments/assets/ea6c7584-694b-494f-8463-8a892a7dd2bb" />

</details>

<details>
<summary><strong>Hashtags</strong></summary>

#### 증분 조회 SQL

```sql
SELECT
  h.id,
  h.tag_name AS tagName,
  h.usage_count AS usageCount,
  CASE WHEN h.usage_count > 0 THEN 'index' ELSE 'delete' END AS es_action,
  h.updated_at AS sync_updated_at
FROM hashtag h
WHERE h.updated_at > DATE_SUB(:sql_last_value, INTERVAL 2 SECOND)
ORDER BY h.updated_at ASC, h.id ASC
```

#### 복합 인덱스 추가 (updated_at, id)

`hashtags`도 `users`와 동일하게 `updated_at` 조건 조회와 `updated_at, id` 정렬을 함께 사용하는 조회 패턴이라서
`(updated_at, id)` 복합 인덱스를 추가했습니다.

변경 전에는 EXPLAIN 상 table full scan이 확인됐고,
인덱스 추가 후에는 index range scan으로 개선된 것을 확인했습니다.

#### 변경 전 EXPLAIN

<img width="902" height="142" alt="동기화-변경전-hashtag" src="https://github.com/user-attachments/assets/60f2ec5a-6aa1-45fa-b66f-8f448ecba220" />

#### 변경 후 EXPLAIN

<img width="1800" height="89" alt="동기화-변경후-hashtag" src="https://github.com/user-attachments/assets/eeb0ef19-adeb-4883-bc4a-f2c97f0e90cd" />

</details>

<details>
<summary><strong>Posts</strong></summary>

#### 변경 전 증분 조회 SQL

```sql
SELECT * FROM (
  SELECT
    p.id,
    p.channel,
    p.content,
    u.nickname AS authorNickname,
    COALESCE(GROUP_CONCAT(DISTINCT h.tag_name ORDER BY h.tag_name SEPARATOR ','), '') AS hashtags_csv,
    p.created_at AS createdAt,
    (p.comment_count * 4 + p.like_count + p.sad_count + p.fun_count + p.hype_count) AS popularityScore,
    CASE WHEN p.status = 'ACTIVE' AND p.deleted_at IS NULL THEN 'index' ELSE 'delete' END AS es_action,
    GREATEST(
      p.updated_at,
      COALESCE(u.updated_at, TIMESTAMP('1970-01-01 00:00:00')),
      COALESCE(MAX(ph.updated_at), TIMESTAMP('1970-01-01 00:00:00')),
      COALESCE(MAX(h.updated_at), TIMESTAMP('1970-01-01 00:00:00'))
    ) AS sync_updated_at
  FROM posts p
  LEFT JOIN users u ON u.id = p.user_id
  LEFT JOIN post_hashtag ph ON ph.post_id = p.id
  LEFT JOIN hashtag h ON h.id = ph.hashtag_id
  GROUP BY p.id, p.channel, p.content, u.nickname, p.created_at, p.comment_count, p.like_count, p.sad_count, p.fun_count, p.hype_count, p.status, p.deleted_at, p.updated_at, u.updated_at
) t
WHERE t.sync_updated_at > DATE_SUB(:sql_last_value, INTERVAL 3 SECOND)
ORDER BY t.sync_updated_at ASC, t.id ASC
```

#### 변경 후 증분 조회 SQL

```sql
SELECT
  p.id,
  p.channel,
  p.content,
  u.nickname AS authorNickname,
  COALESCE(GROUP_CONCAT(DISTINCT h.tag_name ORDER BY h.tag_name SEPARATOR ','), '') AS hashtags_csv,
  p.created_at AS createdAt,
  (p.comment_count * 4 + p.like_count + p.sad_count + p.fun_count + p.hype_count) AS popularityScore,
  CASE WHEN p.status = 'ACTIVE' AND p.deleted_at IS NULL THEN 'index' ELSE 'delete' END AS es_action,
  p.updated_at AS sync_updated_at
FROM posts p
LEFT JOIN users u ON u.id = p.user_id
LEFT JOIN post_hashtag ph ON ph.post_id = p.id
LEFT JOIN hashtag h ON h.id = ph.hashtag_id
WHERE p.updated_at > DATE_SUB(:sql_last_value, INTERVAL 2 SECOND)
GROUP BY p.id, p.channel, p.content, u.nickname, p.created_at, p.comment_count, p.like_count, p.sad_count, p.fun_count, p.hype_count, p.status, p.deleted_at, p.updated_at
ORDER BY p.updated_at ASC, p.id ASC
```

#### 증분 추적 기준 일원화 및 복합 인덱스 추가(updated_at, id)

기존 `posts` 파이프라인은 `posts`, `users`, `post_hashtag`, `hashtag`의 `updated_at` 중
가장 최신 값을 `GREATEST(...)`로 계산한 `sync_updated_at`을 기준으로 증분 대상을 추적하고 있었습니다.

하지만 백엔드에서는 게시글 검색 문서에 영향을 주는 변경이 발생할 때 `posts.updated_at`이 갱신되도록 로직을 변경해서
파이프라인도 같은 기준으로 추적하도록 `posts.updated_at` 기반으로 일원화했습니다.

이와 함께 `WHERE p.updated_at > ...` 조건 조회와 
`ORDER BY p.updated_at, p.id` 정렬을 함께 처리할 수 있도록 `(updated_at, id)` 복합 인덱스를 추가했습니다.

변경 후에는 조인 기반 `sync_updated_at` 계산 없이도
백엔드 로직과 동일한 기준으로 증분 동기화를 추적할 수 있게 되었고, EXPLAIN 상 실행 계획도 개선된 것을 확인했습니다.

#### 변경 전 EXPLAIN
<img width="2848" height="453" alt="동기화-변경전-posts" src="https://github.com/user-attachments/assets/d8a0b2b3-973f-4d27-9f65-a378383a2277" />

#### 변경 후 EXPLAIN
<img width="2019" height="301" alt="동기화-변경후-posts" src="https://github.com/user-attachments/assets/b1575ca9-516d-4874-8b21-e61cd52c123a" />

</details>

---

## Additional Notes (기타 참고사항)

- 운영 검증 결과

  - elasticsearch, logstash 재기동을 정상 확인했습니다.

  - posts 파이프라인이 새 쿼리로 기동되는 로그를 확인했습니다.

  - 앱에서 게시글 본문 수정 후 Elasticsearch 문서 반영을 확인했습니다.

---

## Related Issues
- Ref #54