### PR TITLE
community / 게시글 수정 시 벌크 업데이트로 인한 본문 변경 누락 오류 수정

### DIFF
--- a/module-community/src/main/java/com/beta/community/application/CommunityFacadeService.java
+++ b/module-community/src/main/java/com/beta/community/application/CommunityFacadeService.java
@@ -158,8 +158,8 @@ public class CommunityFacadeService {
         finalImageUrls.removeAll(deletedUrls);
         finalImageUrls.addAll(newImageUrls);
 
-        List<String> hashtags = hashtagService.updateHashtags(post, dto.getHashtags());
         postWriteService.updateContent(post, dto.getContent());
+        List<String> hashtags = hashtagService.updateHashtags(post, dto.getHashtags());
 
         return PostDto.builder()
                 .postId(post.getId())


### PR DESCRIPTION
## PR Title
#### 게시글 수정 시 벌크 업데이트로 인한 본문 변경 누락 오류 해결

---

## What (작업 내용)
- 게시글 수정 시 본문 변경을 해시태그 갱신보다 먼저 수행하도록 수정했습니다.

---

## Key Points (중점 사항)
- 해시태그 변경 시 `touchUpdatedAt` 호출로 영속성 컨텍스트가 초기화되는 흐름을 고려해 처리 순서를 조정했습니다.

---

## Additional Notes (기타 참고사항)
- 없음

---

## Related Issues
- 없음
