### PR TITLE
데이터베이스 연결 예외 처리 및 커넥션 타임아웃 설정 추가

### DIFF
--- a/admin-server/src/main/resources/application.yml
+++ b/admin-server/src/main/resources/application.yml
@@ -7,10 +7,13 @@ spring:
       - classpath:application-core.yml
 
   datasource:
-    url: jdbc:mysql://${DB_HOST}:3306/${DB_SCHEMA}?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${DB_HOST}:3306/${DB_SCHEMA}?serverTimezone=Asia/Seoul&connectTimeout=3000
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      connection-timeout: 5000
+      validation-timeout: 3000
 
   jpa:
     hibernate:

--- a/admin-server/src/test/java/com/beta/controller/user/UserControllerApiTest.java
+++ b/admin-server/src/test/java/com/beta/controller/user/UserControllerApiTest.java
@@ -124,9 +124,14 @@ class UserControllerApiTest extends MysqlRedisTestContainer {
 
     @Test
     @Sql(
-            scripts = {"/sql/admin-user-test-data.sql", "/sql/admin-user-statistics-test-data.sql"},
+            scripts = {
+                    "/sql/admin-user-cleanup.sql",
+                    "/sql/admin-user-test-data.sql",
+                    "/sql/admin-user-statistics-test-data.sql"
+            },
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
+    @Sql(scripts = "/sql/admin-user-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void 관리자_사용자통계_조회시_상태별_필터가_적용된_성별_나이_집계데이터를_반환한다() {
         // given
         String accessToken = jwtTokenProvider.generateAccessToken(1L, null, "ADMIN", AdminAuthConstants.ADMIN_CLIENT);

--- a/module-core/src/main/java/com/beta/core/exception/ErrorCode.java
+++ b/module-core/src/main/java/com/beta/core/exception/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
     INVALID_CURSOR(HttpStatus.BAD_REQUEST, "SEARCH001", "커서의 score, id는 둘다 존재하거나 둘다 비어있어야 합니다."),
     SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SEARCH099", "es 검색 중 오류가 발생했습니다"),
 
+    DATABASE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "DATABASE001", "일시적으로 서비스 이용이 원활하지 않습니다. 잠시 후 다시 시도해주세요."),
+
     KBO_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "KBO001", "현재 순위 정보를 불러올 수 없습니다");
 
     private final HttpStatus status;

--- a/module-core/src/main/java/com/beta/core/exception/GlobalExceptionHandler.java
+++ b/module-core/src/main/java/com/beta/core/exception/GlobalExceptionHandler.java
@@ -2,8 +2,13 @@ package com.beta.core.exception;
 
 import com.beta.core.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.JDBCConnectionException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,6 +16,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLTimeoutException;
+import java.sql.SQLTransientConnectionException;
 import java.util.List;
 
 @Slf4j
@@ -86,6 +94,37 @@ public class GlobalExceptionHandler {
         log.warn("Method not allowed: {}", e.getMethod());
         ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(response);
+    }
+
+    /**
+     * 데이터베이스 연결 및 리소스 장애 예외 처리
+     */
+    @ExceptionHandler({
+            CannotGetJdbcConnectionException.class,
+            CannotCreateTransactionException.class,
+            DataAccessResourceFailureException.class,
+            JDBCConnectionException.class,
+            SQLTransientConnectionException.class,
+            SQLNonTransientConnectionException.class
+    })
+    public ResponseEntity<ErrorResponse> handleDatabaseUnavailableException(Exception e) {
+        log.error("Database unavailable: exception={}, message={}", e.getClass().getSimpleName(), e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.DATABASE_UNAVAILABLE);
+        return ResponseEntity.status(ErrorCode.DATABASE_UNAVAILABLE.getStatus()).body(response);
+    }
+
+    /**
+     * 데이터베이스 타임아웃 예외 처리
+     */
+    @ExceptionHandler({
+            QueryTimeoutException.class,
+            SQLTimeoutException.class,
+            jakarta.persistence.QueryTimeoutException.class
+    })
+    public ResponseEntity<ErrorResponse> handleDatabaseTimeoutException(Exception e) {
+        log.error("Database timeout: exception={}, message={}", e.getClass().getSimpleName(), e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.DATABASE_UNAVAILABLE);
+        return ResponseEntity.status(ErrorCode.DATABASE_UNAVAILABLE.getStatus()).body(response);
     }
 
     /**

--- a/module-core/src/test/java/com/beta/core/exception/GlobalExceptionHandlerTest.java
+++ b/module-core/src/test/java/com/beta/core/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,56 @@
+package com.beta.core.exception;
+
+import com.beta.core.response.ErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void 데이터베이스_연결_장애는_DATABASE_UNAVAILABLE_에러를_반환한다() {
+        // given
+        CannotGetJdbcConnectionException exception = new CannotGetJdbcConnectionException("Could not get JDBC Connection");
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleDatabaseUnavailableException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE); // 503
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.DATABASE_UNAVAILABLE.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.DATABASE_UNAVAILABLE.getMessage());
+    }
+
+    @Test
+    void 데이터베이스_타임아웃은_DATABASE_UNAVAILABLE_에러를_반환한다() {
+        // given
+        QueryTimeoutException exception = new QueryTimeoutException("Query timed out");
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleDatabaseTimeoutException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE); // 503
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.DATABASE_UNAVAILABLE.getCode());
+    }
+
+    @Test
+    void 알수없는_예외는_서버_내부_오류를_반환한다() {
+        // given
+        RuntimeException exception = new RuntimeException("unknown error");
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getCode());
+    }
+}

--- a/user-server/src/main/resources/application.yml
+++ b/user-server/src/main/resources/application.yml
@@ -12,10 +12,13 @@ spring:
       max-request-size: 10MB
 
   datasource:
-    url: jdbc:mysql://${DB_HOST}:3306/${DB_SCHEMA}?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${DB_HOST}:3306/${DB_SCHEMA}?serverTimezone=Asia/Seoul&connectTimeout=3000
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      connection-timeout: 5000
+      validation-timeout: 3000
 
   jpa:
     hibernate:


### PR DESCRIPTION
## PR Title
### 데이터베이스 연결 예외 처리 및 커넥션 타임아웃 설정 추가

---

## What (작업 내용)
- 데이터베이스 연결/리소스 관련 예외를 `503 SERVICE_UNAVAILABLE` 응답으로 처리하도록 공통 예외 핸들러를 추가했습니다.
- 데이터베이스 타임아웃 예외를 `503 SERVICE_UNAVAILABLE` 응답으로 처리하도록 공통 예외 핸들러를 추가했습니다.
- 데이터베이스 장애 응답용 `DATABASE001` 에러 코드를 추가했습니다.
- `user-server`, `admin-server` datasource에 HikariCP 커넥션 대기/검증 타임아웃 설정을 추가했습니다.
- MySQL JDBC URL에 신규 커넥션 생성 시 적용할 `connectTimeout` 설정을 추가했습니다.

---

## Key Points (중점 사항)

### 1. 데이터베이스 예외 핸들러 분리 및 공통 에러 응답

- OCI DB 점검, DB 재시작, connection 끊김 등으로 데이터베이스 연결을 정상적으로 확보하지 못하는 상황에 대해
   기존 fallback 500 응답 대신 `503 SERVICE_UNAVAILABLE` + `DATABASE001` 응답을 반환하도록 했습니다.

- 데이터베이스 연결/리소스 관련 예외와 타임아웃 예외는 서버 로그에서 구분되도록 핸들러를 분리하고,
   클라이언트에는 동일한 `DATABASE001`  에러 코드 응답을 반환하도록 통일했습니다.

- 연결/리소스 예외
  - **CannotGetJdbcConnectionException**
  - **CannotCreateTransactionException**
  - **DataAccessResourceFailureException**
  - **JDBCConnectionException**
  - **SQLTransientConnectionException**
  - **SQLNonTransientConnectionException**

- 타임아웃 예외
  - **QueryTimeoutException**
  - **SQLTimeoutException**
  - **jakarta.persistence.QueryTimeoutException**

### 2. HikariCP · JDBC Connection Timeout 설정

#### HikariCP connection 요청 흐름

```mermaid
flowchart LR
    A["Repository/JPA<br/>DB 작업 필요"] --> B["HikariCP<br/>connection 요청"]
    B --> C["pool에서 idle<br/>connection 탐색"]
    C --> D{"idle connection<br/>있음?"}

    D -- "있음" --> E["connection<br/>생존 확인"]
    E --> F{"validation<br/>성공?"}
    F -- "성공" --> G["connection 대여"]
    F -- "실패" --> H["connection 폐기"]

    D -- "없음" --> I{"새 connection<br/>생성 가능?"}
    H --> I

    I -- "가능" --> J["신규 physical<br/>DB connection 생성"]
    I -- "불가능" --> K["사용 중 connection<br/>반납 대기"]

    J --> L{"생성 성공?"}
    L -- "성공" --> G
    L -- "실패/timeout" --> M["DB connection<br/>예외 발생"]

    K --> N{"대기 시간 내<br/>확보?"}
    N -- "확보" --> G
    N -- "timeout" --> M

    G --> O["Hibernate/JPA<br/>SQL 실행"]
    O --> P["commit/rollback"]
    P --> Q["connection<br/>pool 반납"]

    M --> R["503 SERVICE_UNAVAILABLE<br/>DATABASE001"]

    classDef normal fill:#ffffff,stroke:#d0d7de,color:#24292f,stroke-width:1px;
    classDef decision fill:#f6f8fa,stroke:#8c959f,color:#24292f,stroke-width:1px;
    classDef error fill:#fff5f5,stroke:#d1242f,color:#24292f,stroke-width:1px;
    classDef success fill:#f0fff4,stroke:#1a7f37,color:#24292f,stroke-width:1px;

    class A,B,C,E,H,J,K,O,P,Q normal;
    class D,F,I,L,N decision;
    class G success;
    class M,R error;
```

- DB 접근이 필요한 요청은 `Hibernate/JPA`가 `HikariCP`에서 빌린 `connection`을 통해 SQL을 실행하는 흐름으로 처리됩니다.

- DB 점검/재시작 등으로 기존 `connection`이 끊기거나 신규 `physical DB connection` 생성이 지연될 수 있기 때문에,
  `HikariCP`가 사용 가능한 `connection`을 확보하는 과정에서 요청이 대기할 수 있습니다.

- 이러한 상황에서 사용자 요청이 장시간 대기 상태로 남지 않도록
  `HikariCP`의 `connection` 대여/검증 timeout과 `MySQL JDBC`의 신규 `connection` 생성 timeout을 설정했습니다.

- **hikari connection-timeout: 5000**
  - HikariCP pool에서 connection을 빌리는 전체 대기 시간을 최대 5초로 제한합니다.
  - idle connection 검증, 신규 physical connection 생성, 사용 중인 connection 반납 대기를 이 시간 안에서 처리합니다.

- **hikari validation-timeout: 3000**
  - pool에서 찾은 기존 connection의 생존 확인 시간을 최대 3초로 제한합니다.

- **jdbc connectTimeout=3000**
  - 신규 physical DB connection 생성 시 MySQL JDBC Driver의 TCP 연결 시도 시간을 최대 3초로 제한합니다.

---

## Additional Notes (기타 참고사항)
- SQL 실행 단계의 timeout 설정은 변경하지 않았습니다.
- timeout 수치는 운영 반영 후 애플리케이션 로그와 커넥션 풀 동작을 확인하며 조정할 수 있습니다.
- datasource timeout 기준은 user-server, admin-server에 동일하게 적용했습니다.

---

## Related Issues
- 없음