### PR TITLE
홈 인기 게시글 조회 fallback 적용

### DIFF
--- a/module-community/src/main/java/com/beta/community/application/HomeAppService.java
+++ b/module-community/src/main/java/com/beta/community/application/HomeAppService.java
@@ -44,11 +44,14 @@ public class HomeAppService {
                 .toList();
 
         List<Long> blockedUserIds = userBlockReadService.findBlockedUserIds(userId);
-        List<Post> popularPosts = postQueryRepository.findPopularPostsWithinHours(
+        List<Post> recentPopularPosts = postQueryRepository.findPopularPostsWithinHours(
                 POPULAR_POSTS_HOURS,
                 POPULAR_POSTS_LIMIT,
                 blockedUserIds
         );
+        List<Post> popularPosts = recentPopularPosts.size() < POPULAR_POSTS_LIMIT
+                ? postQueryRepository.findPopularPosts(blockedUserIds, POPULAR_POSTS_LIMIT)
+                : recentPopularPosts;
 
         List<Long> postIds = popularPosts.stream().map(Post::getId).toList();
         List<Long> userIds = popularPosts.stream().map(Post::getUserId).distinct().toList();

--- a/module-community/src/main/java/com/beta/community/infra/repository/PostQueryRepository.java
+++ b/module-community/src/main/java/com/beta/community/infra/repository/PostQueryRepository.java
@@ -154,4 +154,24 @@ public class PostQueryRepository {
                 .limit(limit)
                 .fetch();
     }
+
+    public List<Post> findPopularPosts(List<Long> blockedUserIds, int limit) {
+        QPost post = QPost.post;
+
+        NumberExpression<Integer> totalEmotions = post.likeCount
+                .add(post.sadCount)
+                .add(post.funCount)
+                .add(post.hypeCount);
+
+        return queryFactory
+                .selectFrom(post)
+                .where(
+                        post.status.eq(Status.ACTIVE),
+                        post.channel.eq(Post.Channel.ALL),
+                        blockedUserCondition(blockedUserIds)
+                )
+                .orderBy(totalEmotions.desc(), post.id.desc())
+                .limit(limit)
+                .fetch();
+    }
 }

--- a/module-community/src/test/java/com/beta/community/application/HomeAppServiceTest.java
+++ b/module-community/src/test/java/com/beta/community/application/HomeAppServiceTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -134,7 +136,6 @@ class HomeAppServiceTest {
             when(userBlockReadService.findBlockedUserIds(USER_ID)).thenReturn(List.of());
             when(postQueryRepository.findPopularPostsWithinHours(eq(24), eq(5), anyList()))
                     .thenReturn(List.of());
-
             // when
             HomeDto result = homeAppService.getHomeData(USER_ID);
 
@@ -189,6 +190,115 @@ class HomeAppServiceTest {
             assertThat(result.getPopularPosts()).hasSize(1);
             assertThat(result.getPopularPosts().get(0).getAuthor().getUserId()).isEqualTo(999L);
             assertThat(result.getPopularPosts().get(0).getAuthor().getNickname()).isEqualTo("알 수 없음");
+        }
+
+        @Test
+        @DisplayName("24시간 이내 인기 게시글이 5개 미만이면 전체 인기 게시글로 다시 조회한다")
+        void fallsBackToOverallPopularPostsWhenRecentPostsAreLessThanLimit() {
+            // given
+            when(kboRankingClient.getRankings()).thenReturn(List.of());
+            when(userBlockReadService.findBlockedUserIds(USER_ID)).thenReturn(List.of());
+
+            Post recentPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("최근 게시글")
+                    .channel("ALL")
+                    .build();
+            recentPost.activate();
+
+            Post olderPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("전체 인기 게시글")
+                    .channel("ALL")
+                    .build();
+            olderPost.activate();
+
+            when(postQueryRepository.findPopularPostsWithinHours(eq(24), eq(5), anyList()))
+                    .thenReturn(List.of(recentPost));
+            when(postQueryRepository.findPopularPosts(anyList(), eq(5)))
+                    .thenReturn(List.of(olderPost));
+            when(postImageJpaRepository.findByPostIdInAndStatusOrderByPostIdAscSortAsc(anyList(), any()))
+                    .thenReturn(List.of());
+            when(postHashtagJpaRepository.findByPost_IdIn(anyList()))
+                    .thenReturn(List.of());
+            when(userPort.findAuthorsByIds(anyList()))
+                    .thenReturn(Map.of(USER_ID, AuthorInfo.builder()
+                            .userId(USER_ID)
+                            .nickname("테스트유저")
+                            .teamCode("DOOSAN")
+                            .build()));
+
+            // when
+            HomeDto result = homeAppService.getHomeData(USER_ID);
+
+            // then
+            assertThat(result.getPopularPosts()).hasSize(1);
+            assertThat(result.getPopularPosts().get(0).getContent()).isEqualTo("전체 인기 게시글");
+        }
+
+        @Test
+        @DisplayName("24시간 이내 인기 게시글이 5개면 전체 인기 게시글을 다시 조회하지 않는다")
+        void doesNotFallbackWhenRecentPostsMeetLimit() {
+            // given
+            when(kboRankingClient.getRankings()).thenReturn(List.of());
+            when(userBlockReadService.findBlockedUserIds(USER_ID)).thenReturn(List.of());
+
+            Post firstPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("게시글1")
+                    .channel("ALL")
+                    .build();
+            firstPost.activate();
+
+            Post secondPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("게시글2")
+                    .channel("ALL")
+                    .build();
+            secondPost.activate();
+
+            Post thirdPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("게시글3")
+                    .channel("ALL")
+                    .build();
+            thirdPost.activate();
+
+            Post fourthPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("게시글4")
+                    .channel("ALL")
+                    .build();
+            fourthPost.activate();
+
+            Post fifthPost = Post.builder()
+                    .userId(USER_ID)
+                    .content("게시글5")
+                    .channel("ALL")
+                    .build();
+            fifthPost.activate();
+
+            List<Post> recentPosts = List.of(firstPost, secondPost, thirdPost, fourthPost, fifthPost);
+
+            when(postQueryRepository.findPopularPostsWithinHours(eq(24), eq(5), anyList()))
+                    .thenReturn(recentPosts);
+            when(postImageJpaRepository.findByPostIdInAndStatusOrderByPostIdAscSortAsc(anyList(), any()))
+                    .thenReturn(List.of());
+            when(postHashtagJpaRepository.findByPost_IdIn(anyList()))
+                    .thenReturn(List.of());
+            when(userPort.findAuthorsByIds(anyList()))
+                    .thenReturn(Map.of(USER_ID, AuthorInfo.builder()
+                            .userId(USER_ID)
+                            .nickname("테스트유저")
+                            .teamCode("DOOSAN")
+                            .build()));
+
+            // when
+            HomeDto result = homeAppService.getHomeData(USER_ID);
+
+            // then
+            assertThat(result.getPopularPosts()).hasSize(5);
+            verify(postQueryRepository, never()).findPopularPosts(anyList(), anyInt());
         }
     }
 }

--- a/user-server/src/test/java/com/beta/controller/home/HomeApiTest.java
+++ b/user-server/src/test/java/com/beta/controller/home/HomeApiTest.java
@@ -115,11 +115,13 @@ class HomeApiTest extends ApiTestBase {
                     HomeResponse.class
             );
 
-            // then - 감정 총합 기준 내림차순 (100: 25, 101: 11, 102: 5)
-            assertThat(response.getBody().getPopularPosts()).hasSize(3);
-            assertThat(response.getBody().getPopularPosts().get(0).getPostId()).isEqualTo(100L);
-            assertThat(response.getBody().getPopularPosts().get(1).getPostId()).isEqualTo(101L);
-            assertThat(response.getBody().getPopularPosts().get(2).getPostId()).isEqualTo(102L);
+            // then - 24시간 내 게시글이 5개 미만이므로 전체 인기 게시글 기준 내림차순
+            // 104: 110, 100: 25, 101: 11, 102: 5
+            assertThat(response.getBody().getPopularPosts()).hasSize(4);
+            assertThat(response.getBody().getPopularPosts().get(0).getPostId()).isEqualTo(104L);
+            assertThat(response.getBody().getPopularPosts().get(1).getPostId()).isEqualTo(100L);
+            assertThat(response.getBody().getPopularPosts().get(2).getPostId()).isEqualTo(101L);
+            assertThat(response.getBody().getPopularPosts().get(3).getPostId()).isEqualTo(102L);
         }
 
         @Test
@@ -160,8 +162,8 @@ class HomeApiTest extends ApiTestBase {
         }
 
         @Test
-        @DisplayName("24시간 이전 게시글은 제외된다")
-        void getHome_excludesOldPosts() {
+        @DisplayName("24시간 이내 게시글이 5개 미만이면 24시간 이전 게시글도 포함된다")
+        void getHome_includesOldPostsWhenRecentPostsAreLessThanLimit() {
             // when
             ResponseEntity<HomeResponse> response = restTemplate.exchange(
                     "/api/v1/home",
@@ -170,9 +172,9 @@ class HomeApiTest extends ApiTestBase {
                     HomeResponse.class
             );
 
-            // then - 30시간 전 게시글(id=104)이 없어야 함
+            // then - 최근 게시글이 부족하므로 30시간 전 게시글(id=104)도 포함
             assertThat(response.getBody().getPopularPosts())
-                    .noneMatch(p -> p.getPostId() == 104L);
+                    .anyMatch(p -> p.getPostId() == 104L);
         }
 
         @Test


### PR DESCRIPTION
## PR Title
#### 홈 인기 게시글 조회 fallback 적용

---

## What (작업 내용)
- 홈 인기 게시글 조회에 fallbak 로직을 추가했습니다. - 7fca1d7
- 홈 인기 게시글 조회 관련 테스트를 추가했습니다. - b3f718a

---

## Key Points (중점 사항)
- 최근 24시간 이내 인기 게시글이 5개 이상이면 기존처럼 조회합니다.
- 최근 24시간 이내 인기 게시글이 5개 미만이면 전체 인기 게시글 기준으로 다시 조회합니다.

---

## Additional Notes (기타 참고사항)
- 없음


---

## Related Issues
- Ref #43