### PR TITLE
서버 장애 디스코드 알림 추가

### DIFF
--- a/module-core/src/main/java/com/beta/core/config/AsyncConfig.java
+++ b/module-core/src/main/java/com/beta/core/config/AsyncConfig.java
@@ -32,4 +32,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "discordAlertExecutor")
+    public Executor discordAlertExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("discord-alert-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/module-core/src/main/java/com/beta/core/exception/GlobalExceptionHandler.java
+++ b/module-core/src/main/java/com/beta/core/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.beta.core.exception;
 
 import com.beta.core.response.ErrorResponse;
+import com.beta.core.notification.DiscordWebhookService;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.JDBCConnectionException;
 import org.springframework.dao.DataAccessResourceFailureException;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientConnectionException;
@@ -24,6 +26,12 @@ import java.util.List;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final DiscordWebhookService discordWebhookService;
+
+    public GlobalExceptionHandler(DiscordWebhookService discordWebhookService) {
+        this.discordWebhookService = discordWebhookService;
+    }
 
     /**
      * 비즈니스 로직 예외 처리
@@ -107,8 +115,9 @@ public class GlobalExceptionHandler {
             SQLTransientConnectionException.class,
             SQLNonTransientConnectionException.class
     })
-    public ResponseEntity<ErrorResponse> handleDatabaseUnavailableException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleDatabaseUnavailableException(Exception e, HttpServletRequest request) {
         log.error("Database unavailable: exception={}, message={}", e.getClass().getSimpleName(), e.getMessage(), e);
+        discordWebhookService.sendErrorAlert("Database Unavailable", 503, request.getMethod(), request.getRequestURI(), e);
         ErrorResponse response = ErrorResponse.of(ErrorCode.DATABASE_UNAVAILABLE);
         return ResponseEntity.status(ErrorCode.DATABASE_UNAVAILABLE.getStatus()).body(response);
     }
@@ -121,8 +130,9 @@ public class GlobalExceptionHandler {
             SQLTimeoutException.class,
             jakarta.persistence.QueryTimeoutException.class
     })
-    public ResponseEntity<ErrorResponse> handleDatabaseTimeoutException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleDatabaseTimeoutException(Exception e, HttpServletRequest request) {
         log.error("Database timeout: exception={}, message={}", e.getClass().getSimpleName(), e.getMessage(), e);
+        discordWebhookService.sendErrorAlert("Database Timeout", 503, request.getMethod(), request.getRequestURI(), e);
         ErrorResponse response = ErrorResponse.of(ErrorCode.DATABASE_UNAVAILABLE);
         return ResponseEntity.status(ErrorCode.DATABASE_UNAVAILABLE.getStatus()).body(response);
     }
@@ -131,8 +141,9 @@ public class GlobalExceptionHandler {
      * 예상하지 못한 예외 처리 (Fallback)
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.error("Unexpected exception occurred", e);
+        discordWebhookService.sendErrorAlert("Unexpected Server Error", 500, request.getMethod(), request.getRequestURI(), e);
         ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }

--- a/module-core/src/main/java/com/beta/core/notification/DiscordWebhookService.java
+++ b/module-core/src/main/java/com/beta/core/notification/DiscordWebhookService.java
@@ -1,0 +1,107 @@
+package com.beta.core.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+public class DiscordWebhookService {
+
+    private static final long ALERT_DEDUP_WINDOW_MILLIS = 60_000L;
+
+    private final WebClient webClient;
+    private final String webhookUrl;
+    private final String applicationName;
+    private final Map<String, Long> alertSentAt = new ConcurrentHashMap<>();
+
+    public DiscordWebhookService(
+            WebClient webClient,
+            @Value("${DISCORD_ERROR_WEBHOOK_URL:}") String webhookUrl,
+            @Value("${management.metrics.tags.application:beta-server}") String applicationName
+    ) {
+        this.webClient = webClient;
+        this.webhookUrl = webhookUrl;
+        this.applicationName = applicationName;
+    }
+
+    @Async("discordAlertExecutor")
+    public void sendErrorAlert(String title, int statusCode, String httpMethod, String requestUri, Exception exception) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            return;
+        }
+
+        String dedupKey = createDedupKey(title, statusCode, httpMethod, requestUri, exception);
+        if (!shouldSendAlert(dedupKey, System.currentTimeMillis())) {
+            log.debug("Discord error alert suppressed: key={}", dedupKey);
+            return;
+        }
+
+        String message = """
+                ## [%d] %s
+                서버: %s
+                요청: %s %s
+                예외: %s
+                메시지: %s
+                """.formatted(
+                statusCode,
+                title,
+                applicationName,
+                defaultValue(httpMethod),
+                defaultValue(requestUri),
+                exception.getClass().getSimpleName(),
+                defaultValue(exception.getMessage())
+        );
+
+        try {
+            webClient.post()
+                    .uri(webhookUrl)
+                    .bodyValue(Map.of("content", message))
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+        } catch (Exception webhookException) {
+            log.warn("Discord error alert send failed: {}", webhookException.getMessage(), webhookException);
+        }
+    }
+
+    boolean shouldSendAlert(String dedupKey, long nowMillis) {
+        Long previousSentAt = alertSentAt.putIfAbsent(dedupKey, nowMillis);
+        if (previousSentAt == null) {
+            return true;
+        }
+
+        if (nowMillis - previousSentAt < ALERT_DEDUP_WINDOW_MILLIS) {
+            return false;
+        }
+
+        alertSentAt.put(dedupKey, nowMillis);
+        return true;
+    }
+
+    String createDedupKey(String title, int statusCode, String httpMethod, String requestUri, Exception exception) {
+        if (statusCode == 503) {
+            return "503:" + title;
+        }
+
+        return "%d:%s:%s:%s:%s".formatted(
+                statusCode,
+                title,
+                defaultValue(httpMethod),
+                defaultValue(requestUri),
+                exception.getClass().getSimpleName()
+        );
+    }
+
+    String defaultValue(String value) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        return value;
+    }
+}

--- a/module-core/src/test/java/com/beta/core/exception/GlobalExceptionHandlerTest.java
+++ b/module-core/src/test/java/com/beta/core/exception/GlobalExceptionHandlerTest.java
@@ -1,56 +1,70 @@
 package com.beta.core.exception;
 
+import com.beta.core.notification.DiscordWebhookService;
 import com.beta.core.response.ErrorResponse;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 class GlobalExceptionHandlerTest {
 
-    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+    private final DiscordWebhookService discordWebhookService = Mockito.mock(DiscordWebhookService.class);
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler(discordWebhookService);
 
     @Test
     void 데이터베이스_연결_장애는_DATABASE_UNAVAILABLE_에러를_반환한다() {
         // given
         CannotGetJdbcConnectionException exception = new CannotGetJdbcConnectionException("Could not get JDBC Connection");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
 
         // when
-        ResponseEntity<ErrorResponse> response = handler.handleDatabaseUnavailableException(exception);
+        ResponseEntity<ErrorResponse> response = handler.handleDatabaseUnavailableException(exception, request);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE); // 503
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.DATABASE_UNAVAILABLE.getCode());
         assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.DATABASE_UNAVAILABLE.getMessage());
+        verify(discordWebhookService)
+                .sendErrorAlert("Database Unavailable", 503, "GET", "/api/test", exception);
     }
 
     @Test
     void 데이터베이스_타임아웃은_DATABASE_UNAVAILABLE_에러를_반환한다() {
         // given
         QueryTimeoutException exception = new QueryTimeoutException("Query timed out");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/posts");
 
         // when
-        ResponseEntity<ErrorResponse> response = handler.handleDatabaseTimeoutException(exception);
+        ResponseEntity<ErrorResponse> response = handler.handleDatabaseTimeoutException(exception, request);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE); // 503
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.DATABASE_UNAVAILABLE.getCode());
+        verify(discordWebhookService)
+                .sendErrorAlert("Database Timeout", 503, "POST", "/api/posts", exception);
     }
 
     @Test
     void 알수없는_예외는_서버_내부_오류를_반환한다() {
         // given
         RuntimeException exception = new RuntimeException("unknown error");
+        MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/posts/1");
 
         // when
-        ResponseEntity<ErrorResponse> response = handler.handleException(exception);
+        ResponseEntity<ErrorResponse> response = handler.handleException(exception, request);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getCode());
+        verify(discordWebhookService)
+                .sendErrorAlert("Unexpected Server Error", 500, "DELETE", "/api/posts/1", exception);
     }
 }

--- a/module-core/src/test/java/com/beta/core/notification/DiscordWebhookErrorLiveTest.java
+++ b/module-core/src/test/java/com/beta/core/notification/DiscordWebhookErrorLiveTest.java
@@ -1,0 +1,116 @@
+package com.beta.core.notification;
+
+import com.beta.core.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled("디스코드 웹훅 실연동 확인이 필요할 때만 수동 실행")
+class DiscordWebhookErrorLiveTest {
+
+    @Test
+    void 데이터베이스_연결_장애_발생시_503_디스코드_알림을_전송한다() {
+        // given
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(createDiscordWebhookService());
+        CannotGetJdbcConnectionException exception =
+                new CannotGetJdbcConnectionException("Live test database unavailable");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/live-test/database-unavailable");
+
+        // when
+        var response = handler.handleDatabaseUnavailableException(exception, request);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+    }
+
+    @Test
+    void 데이터베이스_타임아웃_발생시_503_디스코드_알림을_전송한다() {
+        // given
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(createDiscordWebhookService());
+        QueryTimeoutException exception = new QueryTimeoutException("Live test database timeout");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/live-test/database-timeout");
+
+        // when
+        var response = handler.handleDatabaseTimeoutException(exception, request);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+    }
+
+    @Test
+    void 예상하지못한_예외_발생시_500_디스코드_알림을_전송한다() {
+        // given
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(createDiscordWebhookService());
+        RuntimeException exception = new RuntimeException("Live test unexpected exception");
+        MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/live-test/unexpected-error");
+
+        // when
+        var response = handler.handleException(exception, request);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(500);
+    }
+
+    private DiscordWebhookService createDiscordWebhookService() {
+        WebClient webClient = WebClient.builder().build();
+        String webhookUrl = readEnvValue("DISCORD_ERROR_WEBHOOK_URL");
+        assertThat(webhookUrl)
+                .as("DISCORD_ERROR_WEBHOOK_URL must be set for live webhook test")
+                .isNotBlank();
+        return new DiscordWebhookService(webClient, webhookUrl, "beta-user-server");
+    }
+
+    private String readEnvValue(String key) {
+        Path envPath = findEnvPath();
+
+        try {
+            List<String> lines = Files.readAllLines(envPath);
+            for (String line : lines) {
+                String trimmedLine = line.trim();
+                if (trimmedLine.isEmpty() || trimmedLine.startsWith("#")) {
+                    continue;
+                }
+
+                int separatorIndex = trimmedLine.indexOf('=');
+                if (separatorIndex < 0) {
+                    continue;
+                }
+
+                String currentKey = trimmedLine.substring(0, separatorIndex).trim();
+                if (!currentKey.equals(key)) {
+                    continue;
+                }
+
+                return trimmedLine.substring(separatorIndex + 1).trim();
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException(".env file read failed", exception);
+        }
+
+        return null;
+    }
+
+    private Path findEnvPath() {
+        Path currentPath = Path.of("").toAbsolutePath();
+
+        for (int depth = 0; depth < 4 && currentPath != null; depth++) {
+            Path envPath = currentPath.resolve(".env");
+            if (Files.exists(envPath)) {
+                return envPath;
+            }
+            currentPath = currentPath.getParent();
+        }
+
+        throw new IllegalStateException(".env file must exist for live webhook test");
+    }
+}

--- a/module-core/src/test/java/com/beta/core/notification/DiscordWebhookServiceTest.java
+++ b/module-core/src/test/java/com/beta/core/notification/DiscordWebhookServiceTest.java
@@ -1,0 +1,81 @@
+package com.beta.core.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiscordWebhookServiceTest {
+
+    @Test
+    void defaultValue는_blank값을_대시로_변환한다() {
+        // given
+        WebClient webClient = WebClient.builder().build();
+        DiscordWebhookService service = new DiscordWebhookService(webClient, "", "beta-user-server");
+
+        // when
+        String nullValue = service.defaultValue(null);
+        String blankValue = service.defaultValue(" ");
+        String plainValue = service.defaultValue("POST");
+
+        // then
+        assertThat(nullValue).isEqualTo("-");
+        assertThat(blankValue).isEqualTo("-");
+        assertThat(plainValue).isEqualTo("POST");
+    }
+
+    @Test
+    void shouldSendAlert는_같은_키를_1분_내에는_한번만_허용한다() {
+        // given
+        WebClient webClient = WebClient.builder().build();
+        DiscordWebhookService service = new DiscordWebhookService(webClient, "", "beta-user-server");
+
+        // when
+        boolean first = service.shouldSendAlert("503:Database Unavailable", 1_000L);
+        boolean second = service.shouldSendAlert("503:Database Unavailable", 30_000L);
+        boolean third = service.shouldSendAlert("503:Database Unavailable", 61_001L);
+
+        // then
+        assertThat(first).isTrue();
+        assertThat(second).isFalse();
+        assertThat(third).isTrue();
+    }
+
+    @Test
+    void createDedupKey는_503이면_URI대신_에러종류기준으로_묶는다() {
+        // given
+        WebClient webClient = WebClient.builder().build();
+        DiscordWebhookService service = new DiscordWebhookService(webClient, "", "beta-user-server");
+
+        // when
+        String dedupKey = service.createDedupKey(
+                "Database Unavailable",
+                503,
+                "GET",
+                "/api/v1/posts",
+                new IllegalStateException("database down")
+        );
+
+        // then
+        assertThat(dedupKey).isEqualTo("503:Database Unavailable");
+    }
+
+    @Test
+    void createDedupKey는_500이면_요청과_예외기준으로_묶는다() {
+        // given
+        WebClient webClient = WebClient.builder().build();
+        DiscordWebhookService service = new DiscordWebhookService(webClient, "", "beta-user-server");
+
+        // when
+        String dedupKey = service.createDedupKey(
+                "Unexpected Server Error",
+                500,
+                "POST",
+                "/api/v1/posts",
+                new IllegalArgumentException("boom")
+        );
+
+        // then
+        assertThat(dedupKey).isEqualTo("500:Unexpected Server Error:POST:/api/v1/posts:IllegalArgumentException");
+    }
+}


### PR DESCRIPTION
## PR Title
#### 서버 장애 디스코드 알림 추가

---

## What (작업 내용)
- 서버 장애 발생 시 디스코드 웹훅 알림을 전송하도록 구현했습니다. - e48db39
- 디스코드 알림 관련 단위 테스트와 수동 라이브 테스트를 추가했습니다. - 8fc9e55

---

## Key Points (중점 사항)
- GlobalExceptionHandler 기준으로 알림 대상을 제한했습니다.
   비즈니스 예외(BaseException), 검증/바인딩 예외는 제외하고
   Database Unavailable(503), Database Timeout(503), Unexpected Server Error(500)만 전송합니다.

- 디스코드 알림은 요청 처리와 분리하기 위해 별도 비동기 executor에서 전송하여 
   알림 전송 실패가 API 응답이나 기존 예외 처리 흐름에 영향을 주지 않도록 했습니다.

- 장애 알림 도배를 줄이기 위해 중복 전송 제한을 넣었습니다.
   503은 장애 유형 기준으로 1분 동안 1회만 전송합니다.
   500은 상태코드 + 제목 + 요청 method + URI + 예외 클래스 기준으로 1분 동안 1회만 전송합니다.

- 중복 전송 제한은 별도 저장소를 두지 않고 ConcurrentHashMap 기반의 인메모리 방식으로 구현했습니다.
   현재 운영 환경이 단일 서버 단위로 동작하고, 목적이 전역 정합성 보장보다 운영 알림 도배 방지에 있는 점을 고려해 
   Redis/DB 연동 없이 단순한 방식으로 적용했습니다.

---

## Additional Notes (기타 참고사항)
- 웹훅 URL은 서버 환경변수 DISCORD_ERROR_WEBHOOK_URL로 주입받습니다.

---

## Related Issues
- 없음