### PR TITLE
Redis 기반 게시글 단위 알림 발송 제한 추가

### DIFF
--- a/module-community/src/main/java/com/beta/community/application/CommunityNotificationEventListener.java
+++ b/module-community/src/main/java/com/beta/community/application/CommunityNotificationEventListener.java
@@ -1,10 +1,5 @@
 package com.beta.community.application;
 
-import com.beta.core.event.notification.PostCommentNotificationEvent;
-import com.beta.core.event.notification.PostEmotionNotificationEvent;
-import com.beta.core.port.PushPort;
-import com.beta.core.port.UserPort;
-import com.beta.core.port.dto.AuthorInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -12,15 +7,30 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.List;
 
+import com.beta.core.event.notification.PostCommentNotificationEvent;
+import com.beta.core.event.notification.PostEmotionNotificationEvent;
+import com.beta.core.port.PushPort;
+import com.beta.core.port.UserPort;
+import com.beta.core.port.dto.AuthorInfo;
+
 @Component
 @RequiredArgsConstructor
 public class CommunityNotificationEventListener {
 
     private final UserPort userPort;
     private final PushPort pushPort;
+    private final NotificationThrottleService notificationThrottleService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PostCommentNotificationEvent event) {
+        if (!notificationThrottleService.canSendPostComment(
+                event.actorUserId(),
+                event.targetUserId(),
+                event.postId()
+        )) {
+            return;
+        }
+
         String actorNickname = resolveActorNickname(event.actorUserId());
         pushPort.sendPostCommentNotification(
                 event.targetUserId(),
@@ -32,6 +42,14 @@ public class CommunityNotificationEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PostEmotionNotificationEvent event) {
+        if (!notificationThrottleService.canSendPostEmotion(
+                event.actorUserId(),
+                event.targetUserId(),
+                event.postId()
+        )) {
+            return;
+        }
+
         String actorNickname = resolveActorNickname(event.actorUserId());
         pushPort.sendPostEmotionNotification(
                 event.targetUserId(),

--- a/module-community/src/main/java/com/beta/community/application/NotificationThrottleService.java
+++ b/module-community/src/main/java/com/beta/community/application/NotificationThrottleService.java
@@ -1,0 +1,37 @@
+package com.beta.community.application;
+
+import com.beta.community.infra.repository.NotificationThrottleRedisRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+public class NotificationThrottleService {
+
+    private static final String POST_COMMENT_PREFIX = "POST_COMMENT";
+    private static final String POST_EMOTION_PREFIX = "POST_EMOTION";
+    private static final Duration COMMENT_THROTTLE_DURATION = Duration.ofMinutes(1);
+    private static final Duration EMOTION_THROTTLE_DURATION = Duration.ofMinutes(5);
+
+    private final NotificationThrottleRedisRepository notificationThrottleRedisRepository;
+
+    public NotificationThrottleService(NotificationThrottleRedisRepository notificationThrottleRedisRepository) {
+        this.notificationThrottleRedisRepository = notificationThrottleRedisRepository;
+    }
+
+    public boolean canSendPostComment(Long actorUserId, Long targetUserId, Long postId) {
+        return tryAcquire(buildKey(POST_COMMENT_PREFIX, actorUserId, targetUserId, postId), COMMENT_THROTTLE_DURATION);
+    }
+
+    public boolean canSendPostEmotion(Long actorUserId, Long targetUserId, Long postId) {
+        return tryAcquire(buildKey(POST_EMOTION_PREFIX, actorUserId, targetUserId, postId), EMOTION_THROTTLE_DURATION);
+    }
+
+    String buildKey(String type, Long actorUserId, Long targetUserId, Long postId) {
+        return "notification:throttle:" + type + ":" + actorUserId + ":" + targetUserId + ":" + postId;
+    }
+
+    boolean tryAcquire(String key, Duration window) {
+        return notificationThrottleRedisRepository.tryAcquire(key, window);
+    }
+}

--- a/module-community/src/main/java/com/beta/community/infra/repository/NotificationThrottleRedisRepository.java
+++ b/module-community/src/main/java/com/beta/community/infra/repository/NotificationThrottleRedisRepository.java
@@ -1,0 +1,26 @@
+package com.beta.community.infra.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class NotificationThrottleRedisRepository {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean tryAcquire(String key, Duration ttl) {
+        try {
+            Boolean result = stringRedisTemplate.opsForValue().setIfAbsent(key, "1", ttl);
+            return Boolean.TRUE.equals(result);
+        } catch (Exception e) {
+            log.warn("Redis 알림 스로틀 체크 실패, fail-closed 처리: key={}", key, e);
+            return false;
+        }
+    }
+}

--- a/module-community/src/test/java/com/beta/community/application/CommunityNotificationEventListenerTest.java
+++ b/module-community/src/test/java/com/beta/community/application/CommunityNotificationEventListenerTest.java
@@ -5,7 +5,6 @@ import com.beta.core.event.notification.PostEmotionNotificationEvent;
 import com.beta.core.port.PushPort;
 import com.beta.core.port.UserPort;
 import com.beta.core.port.dto.AuthorInfo;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,11 +14,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("CommunityNotificationEventListener 단위 테스트")
 class CommunityNotificationEventListenerTest {
 
     @Mock
@@ -28,18 +27,21 @@ class CommunityNotificationEventListenerTest {
     @Mock
     private PushPort pushPort;
 
+    @Mock
+    private NotificationThrottleService notificationThrottleService;
+
     @InjectMocks
     private CommunityNotificationEventListener communityNotificationEventListener;
 
     @Test
-    @DisplayName("댓글 알림 이벤트를 수신하면 게시글 작성자에게 푸시를 보낸다")
-    void handle_sendsCommentPush_whenPostCommentNotificationEventReceived() {
+    void 댓글_알림_이벤트를_수신하고_허용되면_게시글_작성자에게_푸시를_보낸다() {
         // given
         Long actorUserId = 1L;
         Long targetUserId = 2L;
         Long postId = 10L;
         Long commentId = 100L;
 
+        when(notificationThrottleService.canSendPostComment(actorUserId, targetUserId, postId)).thenReturn(true);
         when(userPort.findAuthorsByIds(List.of(actorUserId))).thenReturn(
                 Map.of(actorUserId, AuthorInfo.builder()
                         .userId(actorUserId)
@@ -58,13 +60,33 @@ class CommunityNotificationEventListenerTest {
     }
 
     @Test
-    @DisplayName("공감 알림 이벤트를 수신하면 게시글 작성자에게 푸시를 보낸다")
-    void handle_sendsEmotionPush_whenPostEmotionNotificationEventReceived() {
+    void 댓글_알림_이벤트를_수신하고_차단되면_게시글_작성자에게_푸시를_보내지_않는다() {
+        // given
+        Long actorUserId = 1L;
+        Long targetUserId = 2L;
+        Long postId = 10L;
+        Long commentId = 100L;
+
+        when(notificationThrottleService.canSendPostComment(actorUserId, targetUserId, postId)).thenReturn(false);
+
+        // when
+        communityNotificationEventListener.handle(
+                new PostCommentNotificationEvent(actorUserId, targetUserId, postId, commentId)
+        );
+
+        // then
+        verify(userPort, never()).findAuthorsByIds(List.of(actorUserId));
+        verify(pushPort, never()).sendPostCommentNotification(targetUserId, "작성자A", postId, commentId);
+    }
+
+    @Test
+    void 공감_알림_이벤트를_수신하고_허용되면_게시글_작성자에게_푸시를_보낸다() {
         // given
         Long actorUserId = 1L;
         Long targetUserId = 2L;
         Long postId = 10L;
 
+        when(notificationThrottleService.canSendPostEmotion(actorUserId, targetUserId, postId)).thenReturn(true);
         when(userPort.findAuthorsByIds(List.of(actorUserId))).thenReturn(
                 Map.of(actorUserId, AuthorInfo.builder()
                         .userId(actorUserId)
@@ -80,5 +102,24 @@ class CommunityNotificationEventListenerTest {
 
         // then
         verify(pushPort).sendPostEmotionNotification(targetUserId, "작성자A", "LIKE", postId);
+    }
+
+    @Test
+    void 공감_알림_이벤트를_수신하고_차단되면_게시글_작성자에게_푸시를_보내지_않는다() {
+        // given
+        Long actorUserId = 1L;
+        Long targetUserId = 2L;
+        Long postId = 10L;
+
+        when(notificationThrottleService.canSendPostEmotion(actorUserId, targetUserId, postId)).thenReturn(false);
+
+        // when
+        communityNotificationEventListener.handle(
+                new PostEmotionNotificationEvent(actorUserId, targetUserId, "LIKE", postId)
+        );
+
+        // then
+        verify(userPort, never()).findAuthorsByIds(List.of(actorUserId));
+        verify(pushPort, never()).sendPostEmotionNotification(targetUserId, "작성자A", "LIKE", postId);
     }
 }

--- a/module-community/src/test/java/com/beta/community/application/NotificationThrottleServiceTest.java
+++ b/module-community/src/test/java/com/beta/community/application/NotificationThrottleServiceTest.java
@@ -1,0 +1,83 @@
+package com.beta.community.application;
+
+import com.beta.community.infra.repository.NotificationThrottleRedisRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationThrottleServiceTest {
+
+    @Test
+    void 같은_사용자가_같은_게시글에_댓글_알림을_연속_시도하면_제한_시간_내_두_번째_요청은_차단한다() {
+        // given
+        NotificationThrottleRedisRepository notificationThrottleRedisRepository = mock(NotificationThrottleRedisRepository.class);
+        NotificationThrottleService notificationThrottleService =
+                new NotificationThrottleService(notificationThrottleRedisRepository);
+
+        when(notificationThrottleRedisRepository.tryAcquire(
+                "notification:throttle:POST_COMMENT:1:2:3",
+                Duration.ofMinutes(1)
+        )).thenReturn(true, false);
+
+        // when
+        boolean firstAttempt = notificationThrottleService.canSendPostComment(1L, 2L, 3L);
+        boolean secondAttempt = notificationThrottleService.canSendPostComment(1L, 2L, 3L);
+
+        // then
+        assertThat(firstAttempt).isTrue();
+        assertThat(secondAttempt).isFalse();
+    }
+
+    @Test
+    void 다른_사용자의_댓글_알림은_같은_제한_시간_안에서도_각각_허용한다() {
+        // given
+        NotificationThrottleRedisRepository notificationThrottleRedisRepository = mock(NotificationThrottleRedisRepository.class);
+        NotificationThrottleService notificationThrottleService =
+                new NotificationThrottleService(notificationThrottleRedisRepository);
+
+        when(notificationThrottleRedisRepository.tryAcquire(
+                "notification:throttle:POST_COMMENT:1:2:3",
+                Duration.ofMinutes(1)
+        )).thenReturn(true);
+        when(notificationThrottleRedisRepository.tryAcquire(
+                "notification:throttle:POST_COMMENT:4:2:3",
+                Duration.ofMinutes(1)
+        )).thenReturn(true);
+
+        // when
+        boolean firstActorAttempt = notificationThrottleService.canSendPostComment(1L, 2L, 3L);
+        boolean secondActorAttempt = notificationThrottleService.canSendPostComment(4L, 2L, 3L);
+
+        // then
+        assertThat(firstActorAttempt).isTrue();
+        assertThat(secondActorAttempt).isTrue();
+    }
+
+    @Test
+    void 같은_사용자가_같은_게시글에_공감_알림을_연속_시도하면_제한_시간_내_두_번째_요청은_차단한다() {
+        // given
+        NotificationThrottleRedisRepository notificationThrottleRedisRepository = mock(NotificationThrottleRedisRepository.class);
+        NotificationThrottleService notificationThrottleService =
+                new NotificationThrottleService(notificationThrottleRedisRepository);
+
+        when(notificationThrottleRedisRepository.tryAcquire(
+                "notification:throttle:POST_EMOTION:1:2:3",
+                Duration.ofMinutes(5)
+        )).thenReturn(true);
+
+        // when
+        boolean allowed = notificationThrottleService.canSendPostEmotion(1L, 2L, 3L);
+
+        // then
+        assertThat(allowed).isTrue();
+        verify(notificationThrottleRedisRepository).tryAcquire(
+                "notification:throttle:POST_EMOTION:1:2:3",
+                Duration.ofMinutes(5)
+        );
+    }
+}


### PR DESCRIPTION
## PR Title
#### Redis 기반 게시글 단위 알림 발송 제한 추가

---

## What (작업 내용)

- 게시글 단위로 댓글/공감 알림의 중복 발송을 제한하는 Redis 기반 스로틀링을 추가했습니다. - 7490573
- 게시글 단위 스로틀링 동작을 검증하는 단위 테스트를 추가했습니다. - 532ac18

---

## Key Points (중점 사항)

- 알림 이벤트 수신 후 실제 푸시 발송 전에 Redis 스로틀 키를 확인하도록 적용했습니다.
   - 스로틀 범위는 actor + target + post + notification type 기준
- 같은 사용자가 같은 게시글에서 반복적으로 댓글/공감 알림을 유발해도 제한 시간 내 추가 발송은 차단되도록 하였습니다. (1분/5분)
- Redis 체크 실패 시에는 중복 발송 방지를 우선해 알림을 차단하도록 처리했습니다.

---

## Additional Notes (기타 참고사항)
- 없음

---

## Related Issues
- 없음
