### PR TITLE
회원탈퇴 시 커뮤니티 데이터 익명화 보존으로 변경

### DIFF
--- a/admin-server/src/main/java/com/beta/adapter/CommunityDataCleanupAdapter.java
+++ b/admin-server/src/main/java/com/beta/adapter/CommunityDataCleanupAdapter.java
@@ -1,53 +1,20 @@
 package com.beta.adapter;
 
 import com.beta.account.application.port.CommunityDataCleanupPort;
-import com.beta.community.infra.repository.CommentJpaRepository;
-import com.beta.community.infra.repository.CommentLikeJpaRepository;
-import com.beta.community.infra.repository.EmotionJpaRepository;
-import com.beta.community.infra.repository.PostHashtagJpaRepository;
-import com.beta.community.infra.repository.PostImageJpaRepository;
-import com.beta.community.infra.repository.PostJpaRepository;
 import com.beta.community.infra.repository.UserBlockJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class CommunityDataCleanupAdapter implements CommunityDataCleanupPort {
 
-    private final PostJpaRepository postJpaRepository;
-    private final CommentJpaRepository commentJpaRepository;
-    private final EmotionJpaRepository emotionJpaRepository;
-    private final CommentLikeJpaRepository commentLikeJpaRepository;
-    private final PostImageJpaRepository postImageJpaRepository;
-    private final PostHashtagJpaRepository postHashtagJpaRepository;
     private final UserBlockJpaRepository userBlockJpaRepository;
 
     @Override
     @Transactional
-    public void deleteAllUserCommunityData(Long userId) {
-        List<Long> userPostIds = postJpaRepository.findAllIdsByUserId(userId);
-
-        if (!userPostIds.isEmpty()) {
-            List<Long> commentIds = commentJpaRepository.findAllIdsByPostIdIn(userPostIds);
-
-            if (!commentIds.isEmpty()) {
-                commentLikeJpaRepository.deleteAllByCommentIdIn(commentIds);
-            }
-
-            commentJpaRepository.deleteAllByPostIdIn(userPostIds);
-            emotionJpaRepository.deleteAllByPostIdIn(userPostIds);
-            postImageJpaRepository.deleteAllByPostIdIn(userPostIds);
-            postHashtagJpaRepository.deleteAllByPostIdIn(userPostIds);
-            postJpaRepository.deleteAllByUserId(userId);
-        }
-
-        commentLikeJpaRepository.deleteAllByUserId(userId);
-        emotionJpaRepository.deleteAllByUserId(userId);
-        commentJpaRepository.deleteAllByUserId(userId);
+    public void deleteUserBlockRelationships(Long userId) {
         userBlockJpaRepository.deleteAllByBlockerIdOrBlockedId(userId);
     }
 }

--- a/module-account/src/main/java/com/beta/account/adapter/UserPortAdapter.java
+++ b/module-account/src/main/java/com/beta/account/adapter/UserPortAdapter.java
@@ -35,6 +35,9 @@ public class UserPortAdapter implements UserPort {
     }
 
     private AuthorInfo toAuthorInfo(User user) {
+        if (user.getStatus() == User.UserStatus.WITHDRAWN) {
+            return AuthorInfo.withdrawn(user.getId());
+        }
         return AuthorInfo.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())

--- a/module-account/src/main/java/com/beta/account/application/AccountAppService.java
+++ b/module-account/src/main/java/com/beta/account/application/AccountAppService.java
@@ -1,6 +1,7 @@
 package com.beta.account.application;
 
 import com.beta.account.application.dto.*;
+import com.beta.account.application.port.CommunityDataCleanupPort;
 import com.beta.account.domain.entity.BaseballTeam;
 import com.beta.account.domain.entity.SignupStep;
 import com.beta.account.domain.entity.User;
@@ -29,6 +30,7 @@ public class AccountAppService {
     private final WelcomeEmailService welcomeEmailService;
     private final UserDeviceWriteService userDeviceWriteService;
     private final DeviceAppService deviceAppService;
+    private final CommunityDataCleanupPort communityDataCleanupPort;
 
     public LoginResult processSocialLogin(String token, SocialProvider socialProvider, String deviceId) {
         SocialUserInfo socialUserInfo = socialUserInfoService.fetchSocialUserInfo(token, socialProvider);
@@ -204,6 +206,7 @@ public class AccountAppService {
         User user = userWriteService.withdraw(userId);
         userDeviceWriteService.deleteAllByUserId(userId);
         refreshTokenService.deleteByUserId(userId);
+        communityDataCleanupPort.deleteUserBlockRelationships(userId);
         return user.getWithdrawnAt();
     }
 }

--- a/module-account/src/main/java/com/beta/account/application/port/CommunityDataCleanupPort.java
+++ b/module-account/src/main/java/com/beta/account/application/port/CommunityDataCleanupPort.java
@@ -2,5 +2,5 @@ package com.beta.account.application.port;
 
 public interface CommunityDataCleanupPort {
 
-    void deleteAllUserCommunityData(Long userId);
+    void deleteUserBlockRelationships(Long userId);
 }

--- a/module-account/src/main/java/com/beta/account/domain/entity/User.java
+++ b/module-account/src/main/java/com/beta/account/domain/entity/User.java
@@ -133,6 +133,13 @@ public class User extends BaseEntity {
     public void withdraw() {
         this.status = UserStatus.WITHDRAWN;
         this.withdrawnAt = java.time.LocalDateTime.now();
+        this.nickname = "탈퇴한 사용자";
+        this.email = null;
+        this.socialId = null;
+        this.bio = null;
+        this.gender = null;
+        this.age = null;
+        this.baseballTeam = null;
     }
 
     public void suspend() {

--- a/module-account/src/main/java/com/beta/account/domain/service/UserCleanupService.java
+++ b/module-account/src/main/java/com/beta/account/domain/service/UserCleanupService.java
@@ -1,6 +1,5 @@
 package com.beta.account.domain.service;
 
-import com.beta.account.application.port.CommunityDataCleanupPort;
 import com.beta.account.domain.entity.User;
 import com.beta.account.infra.repository.UserConsentJpaRepository;
 import com.beta.account.infra.repository.UserDeviceJpaRepository;
@@ -21,7 +20,6 @@ public class UserCleanupService {
     private final UserJpaRepository userJpaRepository;
     private final UserConsentJpaRepository userConsentJpaRepository;
     private final UserDeviceJpaRepository userDeviceJpaRepository;
-    private final CommunityDataCleanupPort communityDataCleanupPort;
 
     private static final int WITHDRAWAL_RETENTION_DAYS = 30;
 
@@ -50,7 +48,6 @@ public class UserCleanupService {
     }
 
     private void deleteUserData(Long userId) {
-        communityDataCleanupPort.deleteAllUserCommunityData(userId);
         userDeviceJpaRepository.deleteAllByUserId(userId);
         userConsentJpaRepository.deleteByUserId(userId);
         userJpaRepository.deleteById(userId);

--- a/module-community/src/main/java/com/beta/community/adapter/CommunityPortAdapter.java
+++ b/module-community/src/main/java/com/beta/community/adapter/CommunityPortAdapter.java
@@ -72,7 +72,7 @@ public class CommunityPortAdapter implements CommunityPort {
         return posts.stream()
                 .map(post -> MyPostInfo.builder()
                         .postId(post.getId())
-                        .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId())))
+                        .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId())))
                         .content(post.getContent())
                         .channel(post.getChannel().name())
                         .images(imagesMap.getOrDefault(post.getId(), List.of()))

--- a/module-community/src/main/java/com/beta/community/adapter/PostPortAdapter.java
+++ b/module-community/src/main/java/com/beta/community/adapter/PostPortAdapter.java
@@ -49,7 +49,7 @@ public class PostPortAdapter implements PostPort {
                         Post::getId,
                         post -> PostInfo.builder()
                                 .id(post.getId())
-                                .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId())))
+                                .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId())))
                                 .channel(post.getChannel().name())
                                 .imageUrls(imageUrlsMap.getOrDefault(post.getId(), List.of()))
                                 .hashtags(hashtagsMap.getOrDefault(post.getId(), List.of()))

--- a/module-community/src/main/java/com/beta/community/application/CommunityFacadeService.java
+++ b/module-community/src/main/java/com/beta/community/application/CommunityFacadeService.java
@@ -61,7 +61,6 @@ public class CommunityFacadeService {
     private final EmotionReadService emotionReadService;
     private final EmotionWriteService emotionWriteService;
     private final PostQueryRepository postQueryRepository;
-    private final PostJpaRepository postJpaRepository;
     private final PostImageJpaRepository postImageJpaRepository;
     private final PostHashtagJpaRepository postHashtagJpaRepository;
     private final CommentLikeJpaRepository commentLikeJpaRepository;
@@ -277,7 +276,7 @@ public class CommunityFacadeService {
         List<PostListDto.PostSummaryDto> postSummaries = posts.stream()
                 .map(post -> PostListDto.PostSummaryDto.builder()
                         .postId(post.getId())
-                        .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId())))
+                        .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId())))
                         .content(post.getContent())
                         .channel(post.getChannel().name())
                         .images(imagesMap.getOrDefault(post.getId(), List.of()))
@@ -349,7 +348,7 @@ public class CommunityFacadeService {
                 blockedUserIds
         );
 
-        AuthorInfo postAuthor = authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId()));
+        AuthorInfo postAuthor = authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId()));
 
         return PostDetailDto.builder()
                 .postId(post.getId())
@@ -474,7 +473,7 @@ public class CommunityFacadeService {
             boolean deleted,
             List<PostDetailDto.CommentDto> replies) {
 
-        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.withdrawn(comment.getUserId()));
 
         return PostDetailDto.CommentDto.builder()
                 .commentId(comment.getId())

--- a/module-community/src/main/java/com/beta/community/application/CommunityNotificationEventListener.java
+++ b/module-community/src/main/java/com/beta/community/application/CommunityNotificationEventListener.java
@@ -61,7 +61,7 @@ public class CommunityNotificationEventListener {
 
     private String resolveActorNickname(Long actorUserId) {
         AuthorInfo actor = userPort.findAuthorsByIds(List.of(actorUserId))
-                .getOrDefault(actorUserId, AuthorInfo.unknown(actorUserId));
+                .getOrDefault(actorUserId, AuthorInfo.withdrawn(actorUserId));
         return actor.getNickname();
     }
 }

--- a/module-community/src/main/java/com/beta/community/application/admin/AdminPostDetailFacadeService.java
+++ b/module-community/src/main/java/com/beta/community/application/admin/AdminPostDetailFacadeService.java
@@ -57,7 +57,7 @@ public class AdminPostDetailFacadeService {
                 authorMap
         );
 
-        AuthorInfo postAuthor = authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId()));
+        AuthorInfo postAuthor = authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId()));
 
         return new AdminPostDetailResult(
                 post.getId(),
@@ -158,7 +158,7 @@ public class AdminPostDetailFacadeService {
             boolean deleted,
             List<AdminPostDetailResult.ReplyResult> replies
     ) {
-        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.withdrawn(comment.getUserId()));
 
         return new AdminPostDetailResult.CommentResult(
                 comment.getId(),
@@ -180,7 +180,7 @@ public class AdminPostDetailFacadeService {
             Map<Long, AuthorInfo> authorMap,
             boolean deleted
     ) {
-        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.unknown(comment.getUserId()));
+        AuthorInfo author = authorMap.getOrDefault(comment.getUserId(), AuthorInfo.withdrawn(comment.getUserId()));
 
         return new AdminPostDetailResult.ReplyResult(
                 comment.getId(),

--- a/module-community/src/main/java/com/beta/community/application/admin/dto/AdminCommunityDashboardMetricsResult.java
+++ b/module-community/src/main/java/com/beta/community/application/admin/dto/AdminCommunityDashboardMetricsResult.java
@@ -29,7 +29,7 @@ public record AdminCommunityDashboardMetricsResult(
         List<RealtimeFeedItem> realtimeFeeds = realtimeFeedPosts.stream()
                 .map(post -> RealtimeFeedItem.from(
                         post,
-                        authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId())),
+                        authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId())),
                         thumbnailUrlMap.get(post.getId())
                 ))
                 .toList();

--- a/module-community/src/main/java/com/beta/community/application/dto/HomeDto.java
+++ b/module-community/src/main/java/com/beta/community/application/dto/HomeDto.java
@@ -70,7 +70,7 @@ public class HomeDto {
         ) {
             return PopularPostDto.builder()
                     .postId(post.getId())
-                    .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.unknown(post.getUserId())))
+                    .author(authorMap.getOrDefault(post.getUserId(), AuthorInfo.withdrawn(post.getUserId())))
                     .content(post.getContent())
                     .channel(post.getChannel().name())
                     .images(imagesMap.getOrDefault(post.getId(), List.of()))

--- a/module-core/src/main/java/com/beta/core/port/dto/AuthorInfo.java
+++ b/module-core/src/main/java/com/beta/core/port/dto/AuthorInfo.java
@@ -18,4 +18,12 @@ public class AuthorInfo {
                 .teamCode(null)
                 .build();
     }
+
+    public static AuthorInfo withdrawn(Long userId) {
+        return AuthorInfo.builder()
+                .userId(userId)
+                .nickname("탈퇴한 사용자")
+                .teamCode(null)
+                .build();
+    }
 }

--- a/user-server/src/main/java/com/beta/adapter/CommunityDataCleanupAdapter.java
+++ b/user-server/src/main/java/com/beta/adapter/CommunityDataCleanupAdapter.java
@@ -1,63 +1,20 @@
 package com.beta.adapter;
 
 import com.beta.account.application.port.CommunityDataCleanupPort;
-import com.beta.community.infra.repository.*;
+import com.beta.community.infra.repository.UserBlockJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class CommunityDataCleanupAdapter implements CommunityDataCleanupPort {
 
-    private final PostJpaRepository postJpaRepository;
-    private final CommentJpaRepository commentJpaRepository;
-    private final EmotionJpaRepository emotionJpaRepository;
-    private final CommentLikeJpaRepository commentLikeJpaRepository;
-    private final PostImageJpaRepository postImageJpaRepository;
-    private final PostHashtagJpaRepository postHashtagJpaRepository;
     private final UserBlockJpaRepository userBlockJpaRepository;
 
     @Override
     @Transactional
-    public void deleteAllUserCommunityData(Long userId) {
-        // 1. 사용자가 작성한 게시글 ID 조회
-        List<Long> userPostIds = postJpaRepository.findAllIdsByUserId(userId);
-
-        // 2. 사용자 게시글에 달린 모든 데이터 삭제 (다른 사용자가 남긴 것 포함)
-        if (!userPostIds.isEmpty()) {
-            // 2-1. 게시글의 댓글 ID 조회
-            List<Long> commentIds = commentJpaRepository.findAllIdsByPostIdIn(userPostIds);
-
-            // 2-2. 댓글에 달린 좋아요 삭제
-            if (!commentIds.isEmpty()) {
-                commentLikeJpaRepository.deleteAllByCommentIdIn(commentIds);
-            }
-
-            // 2-3. 게시글의 댓글 삭제
-            commentJpaRepository.deleteAllByPostIdIn(userPostIds);
-
-            // 2-4. 게시글의 감정표현 삭제
-            emotionJpaRepository.deleteAllByPostIdIn(userPostIds);
-
-            // 2-5. 게시글의 이미지 삭제
-            postImageJpaRepository.deleteAllByPostIdIn(userPostIds);
-
-            // 2-6. 게시글의 해시태그 연결 삭제
-            postHashtagJpaRepository.deleteAllByPostIdIn(userPostIds);
-
-            // 2-7. 게시글 삭제
-            postJpaRepository.deleteAllByUserId(userId);
-        }
-
-        // 3. 사용자가 다른 게시글에 남긴 활동 삭제
-        commentLikeJpaRepository.deleteAllByUserId(userId);
-        emotionJpaRepository.deleteAllByUserId(userId);
-        commentJpaRepository.deleteAllByUserId(userId);
-
-        // 4. 차단 관계 삭제
+    public void deleteUserBlockRelationships(Long userId) {
         userBlockJpaRepository.deleteAllByBlockerIdOrBlockedId(userId);
     }
 }

--- a/user-server/src/test/java/com/beta/controller/account/UserManagementApiTest.java
+++ b/user-server/src/test/java/com/beta/controller/account/UserManagementApiTest.java
@@ -253,57 +253,38 @@ class UserManagementApiTest extends ApiTestBase {
     class DataCleanup {
 
         @Test
-        @DisplayName("사용자 데이터 삭제 - 게시글/댓글/좋아요/감정표현/이미지/해시태그/차단 모두 삭제")
-        void deleteAllUserCommunityData_deletesAllRelatedData() {
+        @DisplayName("회원탈퇴 시 차단 관계만 삭제되고 커뮤니티 데이터는 보존됨")
+        void deleteUserBlockRelationships_onlyDeletesBlocks() {
             // given - 삭제 전 데이터 확인
             assertThat(postJpaRepository.findById(100L)).isPresent();
             assertThat(postImageJpaRepository.findById(1L)).isPresent();
-            assertThat(commentJpaRepository.findById(1L)).isPresent(); // 다른 유저가 쓴 댓글
-            assertThat(commentJpaRepository.findById(2L)).isPresent(); // 본인이 쓴 댓글
-            assertThat(commentJpaRepository.findById(3L)).isPresent(); // 다른 게시글에 쓴 댓글
-            assertThat(commentLikeJpaRepository.findById(1L)).isPresent(); // user4가 누른 좋아요
-            assertThat(commentLikeJpaRepository.findById(2L)).isPresent(); // user2가 댓글1에 누른 좋아요
-            assertThat(emotionJpaRepository.findById(1L)).isPresent(); // user2가 게시글100에 누른 감정
-            assertThat(emotionJpaRepository.findById(2L)).isPresent(); // user4가 게시글200에 누른 감정
+            assertThat(commentJpaRepository.findById(1L)).isPresent();
+            assertThat(commentJpaRepository.findById(2L)).isPresent();
+            assertThat(commentJpaRepository.findById(3L)).isPresent();
+            assertThat(commentLikeJpaRepository.findById(1L)).isPresent();
+            assertThat(commentLikeJpaRepository.findById(2L)).isPresent();
+            assertThat(emotionJpaRepository.findById(1L)).isPresent();
+            assertThat(emotionJpaRepository.findById(2L)).isPresent();
             assertThat(postHashtagJpaRepository.findById(1L)).isPresent();
             assertThat(userBlockJpaRepository.findById(1L)).isPresent();
 
-            // when - user4 커뮤니티 데이터 삭제
-            communityDataCleanupPort.deleteAllUserCommunityData(CLEANUP_TEST_USER);
+            // when - user4 차단 관계 삭제
+            communityDataCleanupPort.deleteUserBlockRelationships(CLEANUP_TEST_USER);
 
-            // then - user4 관련 데이터 삭제 확인
-            // 1. user4의 게시글(100) 삭제됨
-            assertThat(postJpaRepository.findById(100L)).isEmpty();
-
-            // 2. 게시글100의 이미지 삭제됨
-            assertThat(postImageJpaRepository.findById(1L)).isEmpty();
-
-            // 3. 게시글100에 달린 모든 댓글 삭제됨 (다른 유저가 쓴 것 포함)
-            assertThat(commentJpaRepository.findById(1L)).isEmpty();
-            assertThat(commentJpaRepository.findById(2L)).isEmpty();
-
-            // 4. user4가 다른 게시글에 쓴 댓글 삭제됨
-            assertThat(commentJpaRepository.findById(3L)).isEmpty();
-
-            // 5. 게시글100의 댓글에 달린 좋아요 삭제됨 (다른 유저 것 포함)
-            assertThat(commentLikeJpaRepository.findById(2L)).isEmpty();
-
-            // 6. user4가 누른 댓글 좋아요 삭제됨
-            assertThat(commentLikeJpaRepository.findById(1L)).isEmpty();
-
-            // 7. 게시글100에 달린 감정표현 삭제됨 (다른 유저 것 포함)
-            assertThat(emotionJpaRepository.findById(1L)).isEmpty();
-
-            // 8. user4가 다른 게시글에 누른 감정표현 삭제됨
-            assertThat(emotionJpaRepository.findById(2L)).isEmpty();
-
-            // 9. 게시글100의 해시태그 연결 삭제됨
-            assertThat(postHashtagJpaRepository.findById(1L)).isEmpty();
-
-            // 10. user4의 차단 관계 삭제됨
+            // then - 차단 관계만 삭제됨
             assertThat(userBlockJpaRepository.findById(1L)).isEmpty();
 
-            // 11. 다른 유저의 게시글(200)은 유지됨
+            // 커뮤니티 데이터는 모두 보존됨
+            assertThat(postJpaRepository.findById(100L)).isPresent();
+            assertThat(postImageJpaRepository.findById(1L)).isPresent();
+            assertThat(commentJpaRepository.findById(1L)).isPresent();
+            assertThat(commentJpaRepository.findById(2L)).isPresent();
+            assertThat(commentJpaRepository.findById(3L)).isPresent();
+            assertThat(commentLikeJpaRepository.findById(1L)).isPresent();
+            assertThat(commentLikeJpaRepository.findById(2L)).isPresent();
+            assertThat(emotionJpaRepository.findById(1L)).isPresent();
+            assertThat(emotionJpaRepository.findById(2L)).isPresent();
+            assertThat(postHashtagJpaRepository.findById(1L)).isPresent();
             assertThat(postJpaRepository.findById(200L)).isPresent();
         }
     }


### PR DESCRIPTION
## PR Title
#### 회원탈퇴 시 커뮤니티 데이터 익명화 보존으로 변경

---

## What (작업 내용)

- 회원탈퇴 시 닉네임/개인정보 익명화 및 AuthorInfo.withdrawn() 팩토리 메서드 추가 - 4d4f47f
- 커뮤니티 데이터(게시글/댓글/좋아요/감정표현) 보존으로 변경, 차단 관계만 삭제 - 635a311
- 조회 시 탈퇴 사용자 표시를 AuthorInfo.withdrawn()으로 통일 - 22d2a44
- 회원탈퇴 익명화 관련 테스트 수정 - bf60554

---

## Key Points (중점 사항)

- **탈퇴 즉시**: User.withdraw()에서 nickname="탈퇴한 사용자", email/socialId/bio/gender/age/baseballTeam=null 처리
- **게시글/댓글 보존**: 탈퇴 후에도 작성자가 "탈퇴한 사용자"로 표시되며 콘텐츠는 유지
- **30일 후 영구삭제**: User/디바이스/동의 레코드만 삭제, 커뮤니티 데이터는 익명화 상태로 보존
- **차단 관계**: 탈퇴 즉시 삭제 (processWithdrawal 시점)
- **Response 구조 변경 없음**: 클라이언트 수정 불필요

---

## Flow Diagram

```mermaid
sequenceDiagram
    participant Client
    participant Controller
    participant AccountAppService
    participant User
    participant CleanupPort

    Note over Client,CleanupPort: Phase 1: 탈퇴 즉시
    Client->>Controller: DELETE /api/v1/users/me
    Controller->>AccountAppService: processWithdrawal(userId)
    AccountAppService->>User: withdraw()
    Note over User: status=WITHDRAWN<br/>nickname=탈퇴한 사용자<br/>email,socialId,bio=null
    AccountAppService->>AccountAppService: 디바이스/토큰 삭제
    AccountAppService->>CleanupPort: deleteUserBlockRelationships()

    Note over Client,CleanupPort: Phase 2: 30일 후
    Note over AccountAppService: UserCleanupScheduler
    AccountAppService->>AccountAppService: User/디바이스/동의 레코드 삭제
    Note over AccountAppService: 게시글/댓글은 보존
```

---

## Additional Notes (기타 참고사항)
- CommunityDataCleanupPort 메서드명을 deleteAllUserCommunityData → deleteUserBlockRelationships로 변경
- admin-server의 CommunityDataCleanupAdapter도 동일하게 수정
- AuthorInfo.unknown()은 search 모듈 테스트에서 사용 중이라 유지

---

## Related Issues
- 없음