### PR TITLE
환영 메일 실패 재시도용 이메일 아웃박스 패턴 추가

### DIFF
--- a/module-account/src/main/java/com/beta/account/application/AccountAppService.java
+++ b/module-account/src/main/java/com/beta/account/application/AccountAppService.java
@@ -154,7 +154,7 @@ public class AccountAppService {
         userStatusService.validateSignupStep(user, SignupStep.TEAM_SELECTED);
 
         User completedUser = userWriteService.completeSignup(userId);
-        welcomeEmailService.sendWelcomeEmail(completedUser.getEmail(), completedUser.getNickname());
+        welcomeEmailService.sendWelcomeEmail(completedUser.getId(), completedUser.getEmail(), completedUser.getNickname());
 
         return createSignupCompleteResult(completedUser);
     }
@@ -165,7 +165,7 @@ public class AccountAppService {
 
         User.GenderType genderType = gender != null ? User.GenderType.valueOf(gender) : null;
         User completedUser = userWriteService.completeSignupWithInfo(userId, genderType, age);
-        welcomeEmailService.sendWelcomeEmail(completedUser.getEmail(), completedUser.getNickname());
+        welcomeEmailService.sendWelcomeEmail(completedUser.getId(), completedUser.getEmail(), completedUser.getNickname());
 
         return createSignupCompleteResult(completedUser);
     }

--- a/module-account/src/main/java/com/beta/account/domain/entity/EmailOutbox.java
+++ b/module-account/src/main/java/com/beta/account/domain/entity/EmailOutbox.java
@@ -1,0 +1,100 @@
+package com.beta.account.domain.entity;
+
+import com.beta.core.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "email_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailOutbox extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mail_type", nullable = false, length = 30)
+    private MailType mailType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EmailOutboxStatus status;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Column(name = "last_error", length = 1000)
+    private String lastError;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Builder
+    public EmailOutbox(Long userId, MailType mailType, EmailOutboxStatus status,
+                       int retryCount, LocalDateTime nextRetryAt, String lastError,
+                       LocalDateTime sentAt) {
+        this.userId = userId;
+        this.mailType = mailType;
+        this.status = status;
+        this.retryCount = retryCount;
+        this.nextRetryAt = nextRetryAt;
+        this.lastError = lastError;
+        this.sentAt = sentAt;
+    }
+
+    public static EmailOutbox createWelcomeMailFailure(Long userId, String lastError, LocalDateTime nextRetryAt) {
+        return EmailOutbox.builder()
+                .userId(userId)
+                .mailType(MailType.WELCOME)
+                .status(EmailOutboxStatus.PENDING)
+                .retryCount(0)
+                .lastError(lastError)
+                .nextRetryAt(nextRetryAt)
+                .build();
+    }
+
+    public void markSent() {
+        this.status = EmailOutboxStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+        this.lastError = null;
+        this.nextRetryAt = null;
+    }
+
+    public void markRetrying(String lastError, LocalDateTime nextRetryAt) {
+        this.status = EmailOutboxStatus.RETRYING;
+        this.retryCount += 1;
+        this.lastError = lastError;
+        this.nextRetryAt = nextRetryAt;
+    }
+
+    public void markDead(String lastError) {
+        this.status = EmailOutboxStatus.DEAD;
+        this.retryCount += 1;
+        this.lastError = lastError;
+        this.nextRetryAt = null;
+    }
+
+    public enum MailType {
+        WELCOME
+    }
+
+    public enum EmailOutboxStatus {
+        PENDING,
+        RETRYING,
+        SENT,
+        DEAD
+    }
+}

--- a/module-account/src/main/java/com/beta/account/domain/service/WelcomeEmailService.java
+++ b/module-account/src/main/java/com/beta/account/domain/service/WelcomeEmailService.java
@@ -1,26 +1,115 @@
 package com.beta.account.domain.service;
 
+import com.beta.account.domain.entity.EmailOutbox;
+import com.beta.account.domain.entity.EmailOutbox.EmailOutboxStatus;
+import com.beta.account.domain.entity.User;
+import com.beta.account.infra.repository.EmailOutboxJpaRepository;
 import com.beta.core.mail.MailClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class WelcomeEmailService {
 
+    private static final int MAX_RETRY_COUNT = 5;
+
     private final MailClient mailClient;
+    private final EmailOutboxJpaRepository emailOutboxJpaRepository;
+    private final UserReadService userReadService;
 
     @Async("mailExecutor")
-    public void sendWelcomeEmail(String email, String nickName) {
-        log.info("회원가입 환영 메일 발송 시작: email={}, nickName={}", email, nickName);
+    public void sendWelcomeEmail(Long userId, String email, String nickName) {
+        log.info("회원가입 환영 메일 발송 시작: userId={}, email={}, nickName={}", userId, email, nickName);
 
+        try {
+            deliverWelcomeEmail(email, nickName);
+        } catch (RuntimeException e) {
+            saveOutboxFailure(userId, e);
+        }
+    }
+
+    @Transactional
+    public int retryFailedWelcomeEmails() {
+        LocalDateTime now = LocalDateTime.now();
+        List<EmailOutbox> outboxes = emailOutboxJpaRepository
+                .findTop20ByStatusInAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+                        List.of(EmailOutboxStatus.PENDING, EmailOutboxStatus.RETRYING),
+                        now
+                );
+
+        if (outboxes.isEmpty()) {
+            return 0;
+        }
+
+        for (EmailOutbox outbox : outboxes) {
+            try {
+                User user = userReadService.findUserById(outbox.getUserId());
+                deliverWelcomeEmail(user.getEmail(), user.getNickname());
+                outbox.markSent();
+            } catch (RuntimeException e) {
+                handleRetryFailure(outbox, e);
+            }
+        }
+
+        return outboxes.size();
+    }
+
+    public void deliverWelcomeEmail(String email, String nickName) {
         String subject = "[BETA] 회원가입이 완료되었습니다!";
         String content = buildWelcomeEmailContent(nickName);
 
         mailClient.send(email, subject, content);
+    }
+
+    public void saveOutboxFailure(Long userId, RuntimeException e) {
+        try {
+            emailOutboxJpaRepository.save(EmailOutbox.createWelcomeMailFailure(
+                    userId,
+                    truncateErrorMessage(e.getMessage()),
+                    LocalDateTime.now().plusMinutes(1)
+            ));
+        } catch (RuntimeException saveException) {
+            log.error("이메일 아웃박스 저장 실패: userId={}, error={}", userId, saveException.getMessage(), saveException);
+        }
+    }
+
+    public void handleRetryFailure(EmailOutbox outbox, RuntimeException e) {
+        String errorMessage = truncateErrorMessage(e.getMessage());
+        int nextRetryCount = outbox.getRetryCount() + 1;
+
+        if (nextRetryCount >= MAX_RETRY_COUNT) {
+            outbox.markDead(errorMessage);
+            return;
+        }
+
+        outbox.markRetrying(errorMessage, calculateNextRetryAt(nextRetryCount));
+    }
+
+    public LocalDateTime calculateNextRetryAt(int retryCount) {
+        return switch (retryCount) {
+            case 1 -> LocalDateTime.now().plusMinutes(5);
+            case 2 -> LocalDateTime.now().plusMinutes(30);
+            case 3 -> LocalDateTime.now().plusHours(2);
+            default -> LocalDateTime.now().plusHours(6);
+        };
+    }
+
+    public String truncateErrorMessage(String errorMessage) {
+        if (errorMessage == null || errorMessage.isBlank()) {
+            return "메일 발송 실패";
+        }
+        if (errorMessage.length() <= 1000) {
+            return errorMessage;
+        }
+        return errorMessage.substring(0, 1000);
     }
 
     private String buildWelcomeEmailContent(String nickName) {

--- a/module-account/src/main/java/com/beta/account/infra/repository/EmailOutboxJpaRepository.java
+++ b/module-account/src/main/java/com/beta/account/infra/repository/EmailOutboxJpaRepository.java
@@ -1,0 +1,17 @@
+package com.beta.account.infra.repository;
+
+import com.beta.account.domain.entity.EmailOutbox;
+import com.beta.account.domain.entity.EmailOutbox.EmailOutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+public interface EmailOutboxJpaRepository extends JpaRepository<EmailOutbox, Long> {
+
+    List<EmailOutbox> findTop20ByStatusInAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            Collection<EmailOutboxStatus> statuses,
+            LocalDateTime nextRetryAt
+    );
+}

--- a/module-core/src/main/java/com/beta/core/mail/GmailClient.java
+++ b/module-core/src/main/java/com/beta/core/mail/GmailClient.java
@@ -30,6 +30,7 @@ public class GmailClient implements MailClient {
             log.info("메일 발송 성공: to={}", to);
         } catch (MessagingException | MailException e) {
             log.error("메일 발송 실패: to={}, error={}", to, e.getMessage());
+            throw new IllegalStateException("메일 발송에 실패했습니다.", e);
         }
     }
 }

--- a/user-server/src/main/java/com/beta/scheduler/WelcomeEmailRetryScheduler.java
+++ b/user-server/src/main/java/com/beta/scheduler/WelcomeEmailRetryScheduler.java
@@ -1,0 +1,23 @@
+package com.beta.scheduler;
+
+import com.beta.account.domain.service.WelcomeEmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WelcomeEmailRetryScheduler {
+
+    private final WelcomeEmailService welcomeEmailService;
+
+    @Scheduled(fixedDelay = 60000)
+    public void retryFailedWelcomeEmails() {
+        int retryTargetCount = welcomeEmailService.retryFailedWelcomeEmails();
+        if (retryTargetCount > 0) {
+            log.info("Completed scheduled retry for failed welcome emails: count={}", retryTargetCount);
+        }
+    }
+}


### PR DESCRIPTION
## PR Title
#### 환영 메일 실패 재시도용 이메일 아웃박스 패턴 추가


---

## What (작업 내용)

3b783ca
- 이메일 아웃박스 엔티티를 생성했습니다.
- 환영 메일 실패 저장 및 재시도 로직을 추가했습니다.
- 환영 메일 재시도 스케줄러를 추가했습니다.

---

## Key Points (중점 사항)
- 회원가입 성공 흐름은 유지하고, 환영 메일 실패만 별도로 복구하도록 분리했습니다.
- 비동기 환영 메일 발송이 실패하면 email_outbox에 저장하고, 스케줄러가 재시도하도록 구성했습니다.
- 재시도 대상은 PENDING, RETRYING 상태와 next_retry_at 기준으로 조회합니다.
- 메일 발송 성공 시 SENT, 최대 재시도 횟수 초과 시 DEAD 상태로 관리합니다.

---

## Additional Notes (기타 참고사항)
- 없음


---

## Related Issues
- 없음 